### PR TITLE
Restrict when CI builds to master.

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -1,6 +1,15 @@
 # This file is used to configure CI builds using Github actions ref: https://help.github.com/en/categories/automating-your-workflow-with-github-actions 
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 
 name: CIbuild
 


### PR DESCRIPTION
**Change log description**  
Limit github actions runst to the master branch.

**Purpose of the change**  
Reduce the number of github actions builds

**What the code does**  
Only kicks off builds for master and PRs against master.

