### PR TITLE
Fix panic when ByteStreamReader::read receives less data than requested

### DIFF
--- a/src/byte_stream.rs
+++ b/src/byte_stream.rs
@@ -149,7 +149,7 @@ impl Read for ByteStreamReader<'_> {
                     Err(Error::new(ErrorKind::Other, "segment is sealed"))
                 } else {
                     self.offset += cmd.data.len() as i64;
-                    buf.copy_from_slice(&cmd.data);
+                    buf[..cmd.data.len()].copy_from_slice(&cmd.data);
                     Ok(cmd.data.len())
                 }
             }


### PR DESCRIPTION
**Change log description**  
Fix panic when ByteStreamReader::read receives less data than requested

**Purpose of the change**  
Fixed #142

**What the code does**  
Reduce the size of the destination slice to match the source slice.

**How to verify it**  
`cargo test` continues to pass all tests. A specific test for this bug has not been written.
