### PR TITLE
Issue 144: Add Seek implementation to ByteStreamReader

### DIFF
--- a/src/byte_stream.rs
+++ b/src/byte_stream.rs
@@ -164,7 +164,7 @@ impl Read for ByteStreamReader<'_> {
 /// The Seek implementation for ByteStreamReader allows seeking to a byte offset from the beginning
 /// of the stream or a byte offset relative to the current position in the stream.
 /// If the stream has been truncated, the byte offset will be relative to the original beginning of the stream.
-/// Seek from the end of the stream not not implemented.
+/// Seek from the end of the stream is not implemented.
 impl Seek for ByteStreamReader<'_> {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         match pos {


### PR DESCRIPTION
**Change log description**  
Add Seek implementation to ByteStreamReader

**Purpose of the change**  
Partially addresses #144 by allowing for relative and absolute seek from the beginning. Seek from the end is not yet implemented.

**What the code does**  
Updates the private variable ByteStreamReader.offset.

**How to verify it**  
There are no tests to verify this.
