### PR TITLE
Issue 198: ConditionalCheckFailed due to reconnection

### DIFF
--- a/src/reactor/segment_writer.rs
+++ b/src/reactor/segment_writer.rs
@@ -155,8 +155,8 @@ impl SegmentWriter {
                 Ok((reply, connection)) => match reply {
                     Replies::AppendSetup(cmd) => {
                         debug!(
-                            "append setup completed for writer:{:?}/segment:{:?}",
-                            self.id, self.segment
+                            "append setup completed for writer:{:?}/segment:{:?} with latest event number {}",
+                            self.id, self.segment, cmd.last_event_number
                         );
                         self.ack(cmd.last_event_number);
                         connection

--- a/src/reactor/segment_writer.rs
+++ b/src/reactor/segment_writer.rs
@@ -38,10 +38,10 @@ use tokio::sync::oneshot;
 use tracing_futures::Instrument;
 
 pub(crate) struct SegmentWriter {
-    /// Unique id for each EventSegmentWriter.
+    /// Unique id for each SegmentWriter.
     pub(crate) id: WriterId,
 
-    /// The segment that this writer is writing to.
+    /// The segment that this writer writes to.
     pub(crate) segment: ScopedSegment,
 
     /// Client connection that writes to the segmentstore.
@@ -68,7 +68,7 @@ pub(crate) struct SegmentWriter {
     // Delegation token provider used to authenticate client when communicating with segmentstore.
     delegation_token_provider: Arc<DelegationTokenProvider>,
 
-    /// Whether this writer just had reconnection or not.
+    /// Whether this writer just had a reconnection or not.
     pub(crate) reconnect: bool,
 }
 

--- a/src/reactor/segment_writer.rs
+++ b/src/reactor/segment_writer.rs
@@ -68,8 +68,8 @@ pub(crate) struct SegmentWriter {
     // Delegation token provider used to authenticate client when communicating with segmentstore.
     delegation_token_provider: Arc<DelegationTokenProvider>,
 
-    /// Whether this writer just had a reconnection or not.
-    pub(crate) reconnect: bool,
+    /// Number of consecutive reconnections
+    pub(crate) reconnection: i32,
 }
 
 impl SegmentWriter {
@@ -95,7 +95,7 @@ impl SegmentWriter {
             retry_policy,
             delegation_token_provider,
             connection_listener_handle: None,
-            reconnect: false,
+            reconnection: 0,
         }
     }
 
@@ -444,7 +444,7 @@ impl SegmentWriter {
                 .expect("send reconnect signal to reactor");
             return;
         }
-        self.reconnect = true;
+        self.reconnection += 1;
     }
 
     /// Force delegation token provider to refresh.


### PR DESCRIPTION
**Change log description**  

A false `ConditionalCheckFailed` returned due to reconnection. 

What happens is that when client sends an Event `e` to server and server has already accepted `e`, a reconnection is triggered before client receives the ack reply. The `e` is sent to server again due to reconnection so the ConditionalCheckFailed is returned since `e` has already been accepted before.

The temporary fix for this issue it to check if a reconnection happened right before receiving `ConditionalCheckFailed`. If it is then this error could be a false alarm and we can ignore it. However, this is not 100% guaranteed since another writer could write some data to the segment right at the reconnection session of our writer, and in that case the `ConditionalCheckFailed` is true. Right now there is no good way to tell unless we check the data in segment. But based on the discussion in #198, the temporary fix is probably good enough.

**Purpose of the change**  
Fix #198 

NOTE: more investigations are needed, please ignore it for now