### PR TITLE
Perf improvement: Avoid a copy of the routing_key string on every write.

### DIFF
--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -357,10 +357,10 @@ impl ControllerClient for MockController {
             exp: expiry_time.as_secs(),
         };
 
-        let header = Header{
+        let header = Header {
             typ: Some("JWT".to_owned()),
             alg: Algorithm::HS256,
-            .. Default::default()
+            ..Default::default()
         };
 
         let key = b"secret";

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -357,9 +357,11 @@ impl ControllerClient for MockController {
             exp: expiry_time.as_secs(),
         };
 
-        let mut header = Header::default();
-        header.typ = Some("JWT".to_owned());
-        header.alg = Algorithm::HS256;
+        let header = Header{
+            typ: Some("JWT".to_owned()),
+            alg: Algorithm::HS256,
+            .. Default::default()
+        };
 
         let key = b"secret";
         let token = encode(&header, &claims, &EncodingKey::from_secret(key)).expect("encode to JWT token");

--- a/integration_test/src/wirecommand_tests.rs
+++ b/integration_test/src/wirecommand_tests.rs
@@ -805,8 +805,8 @@ async fn test_update_table_entries(factory: &ClientFactory) {
         table_segment_offset: -1,
     });
     let mut versions = Vec::new();
-    versions.push(0 as i64);
-    versions.push(27 as i64); //  why return version is 27.
+    versions.push(0_i64);
+    versions.push(27_i64); //  why return version is 27.
     let reply = Replies::TableEntriesUpdated(TableEntriesUpdatedCommand {
         request_id: 19,
         updated_versions: versions,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -468,7 +468,16 @@ impl StreamSegments {
         Ok(())
     }
 
-    pub fn get_segment(&self, key: f64) -> ScopedSegment {
+    /// Selects a segment using a routing key.
+    pub fn get_segment_for_routing_key(&self, routing_key: &Option<String>, rand_f64: fn() -> f64) -> &ScopedSegment {
+        if let Some(key) = routing_key {
+            self.get_segment_for_string(key)
+        } else {
+            self.get_segment(rand_f64())
+        }
+    }
+
+    pub fn get_segment(&self, key: f64) -> &ScopedSegment {
         assert!(OrderedFloat(key).ge(&OrderedFloat(0.0)), "Key should be >= 0.0");
         assert!(OrderedFloat(key).le(&OrderedFloat(1.0)), "Key should be <= 1.0");
         let r = self
@@ -476,10 +485,10 @@ impl StreamSegments {
             .range(&OrderedFloat(key)..)
             .next()
             .expect("No matching segment found for the given key");
-        r.1.scoped_segment.to_owned()
+        &r.1.scoped_segment
     }
 
-    pub fn get_segment_for_string(&self, str: &str) -> ScopedSegment {
+    pub fn get_segment_for_string(&self, str: &str) -> &ScopedSegment {
         let mut buffer_u16 = vec![0; str.len()];
 
         // convert uft-8 encoded Rust string to utf-16.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -469,7 +469,11 @@ impl StreamSegments {
     }
 
     /// Selects a segment using a routing key.
-    pub fn get_segment_for_routing_key(&self, routing_key: &Option<String>, rand_f64: fn() -> f64) -> &ScopedSegment {
+    pub fn get_segment_for_routing_key(
+        &self,
+        routing_key: &Option<String>,
+        rand_f64: fn() -> f64,
+    ) -> &ScopedSegment {
         if let Some(key) = routing_key {
             self.get_segment_for_string(key)
         } else {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -445,13 +445,13 @@ impl StreamSegments {
     const SEED: u64 = 1741865571; // This is the hashcode of String "EventRouter" in Java client
 
     pub fn new(map_key_segment: BTreeMap<OrderedFloat<f64>, SegmentWithRange>) -> StreamSegments {
-        StreamSegments::is_valid(&map_key_segment).expect("Invalid key segment map");
+        StreamSegments::assert_valid(&map_key_segment);
         StreamSegments {
             key_segment_map: map_key_segment.into(),
         }
     }
 
-    fn is_valid(map: &BTreeMap<OrderedFloat<f64>, SegmentWithRange>) -> Result<(), String> {
+    fn assert_valid(map: &BTreeMap<OrderedFloat<f64>, SegmentWithRange>) {
         if !map.is_empty() {
             let (min_key, _min_seg) = map.iter().next().expect("Error reading min key");
             let (max_key, _max_seg) = map.iter().next_back().expect("Error read max key");
@@ -465,7 +465,6 @@ impl StreamSegments {
                 "Segments should have values only up to 1.0"
             );
         }
-        Ok(())
     }
 
     /// Selects a segment using a routing key.

--- a/src/reactor/segment_selector.rs
+++ b/src/reactor/segment_selector.rs
@@ -10,7 +10,6 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use crate::get_random_f64;
 use pravega_client_channel::ChannelSender;
 use tracing::{debug, warn};
 
@@ -21,6 +20,7 @@ use crate::reactor::event::Incoming;
 use crate::reactor::segment_writer::{Append, SegmentWriter};
 use pravega_client_auth::DelegationTokenProvider;
 use std::sync::Arc;
+use crate::get_random_f64;
 
 /// Maintains mapping from segments to segment writers.
 pub(crate) struct SegmentSelector {
@@ -79,19 +79,10 @@ impl SegmentSelector {
     /// Gets a segment writer by providing an optional routing key. The stream at least owns one
     /// segment so this method should always has writer to return.
     pub(crate) fn get_segment_writer(&mut self, routing_key: &Option<String>) -> &mut SegmentWriter {
-        let segment = self.get_segment_for_event(routing_key);
+        let segment = self.current_segments.get_segment_for_routing_key(routing_key, get_random_f64);
         self.writers
-            .get_mut(&segment)
+            .get_mut(segment)
             .expect("must have corresponding writer")
-    }
-
-    /// Selects a segment using a routing key.
-    pub(crate) fn get_segment_for_event(&mut self, routing_key: &Option<String>) -> ScopedSegment {
-        if let Some(key) = routing_key {
-            self.current_segments.get_segment_for_string(key)
-        } else {
-            self.current_segments.get_segment(get_random_f64())
-        }
     }
 
     /// Maintains an internal segment-writer mapping. Fetches the successor segments from controller
@@ -164,8 +155,8 @@ impl SegmentSelector {
     /// Resends a list of events.
     pub(crate) async fn resend(&mut self, to_resend: Vec<Append>) {
         for append in to_resend {
-            let segment = self.get_segment_for_event(&append.event.routing_key);
-            let segment_writer = self.writers.get_mut(&segment).expect("must have writer");
+            let segment = self.current_segments.get_segment_for_routing_key(&append.event.routing_key, get_random_f64);
+            let segment_writer = self.writers.get_mut(segment).expect("must have writer");
             segment_writer.add_pending(append.event, append.cap_guard);
             if let Err(e) = segment_writer.write_pending_events().await {
                 warn!(

--- a/src/reader_group/reader_group_state.rs
+++ b/src/reader_group/reader_group_state.rs
@@ -20,7 +20,6 @@ use snafu::ResultExt;
 use snafu::{ensure, OptionExt, Snafu};
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-use std::iter::FromIterator;
 use tracing::{debug, info, warn};
 
 const ASSUMED_LAG_MILLIS: u64 = 30000;
@@ -519,7 +518,7 @@ impl ReaderGroupState {
         // add missing successors to future_segments
         for (segment, list) in successors_mapped_to_their_predecessors {
             if !future_segments.contains_key(&segment.scoped_segment) {
-                let required_to_complete = HashSet::from_iter(list.clone().into_iter());
+                let required_to_complete: HashSet<_> = list.clone().into_iter().collect();
                 table.insert(
                     FUTURE.to_owned(),
                     segment.scoped_segment.to_string(),


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
 Avoid a copy of the routing_key string on every write.

**What the code does**  
Borrows the ScopedSegment rather than performing a clone of the string.


