### PR TITLE
Issue 228: Fix acquire segment

### DIFF
--- a/integration_test/src/event_stream_reader_tests.rs
+++ b/integration_test/src/event_stream_reader_tests.rs
@@ -102,7 +102,7 @@ fn test_multi_reader_multi_segments_tail_read(client_factory: &ClientFactory, rt
     let scope_name = Scope::from("testMultiReaderMultiSegmentsTailRead".to_owned());
     let stream_name = Stream::from("testMultiReaderMultiSegmentsTailRead".to_owned());
 
-    const NUM_EVENTS: usize = 10000;
+    const NUM_EVENTS: usize = 2000;
     const EVENT_SIZE: usize = 1024;
 
     let new_stream = rt.block_on(create_scope_stream(

--- a/integration_test/src/event_stream_reader_tests.rs
+++ b/integration_test/src/event_stream_reader_tests.rs
@@ -21,7 +21,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tokio::time::delay_for;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info, warn};
 
@@ -38,10 +37,10 @@ pub fn test_event_stream_reader(config: PravegaStandaloneServiceConfig) {
     let runtime = client_factory.get_runtime();
     test_read_large_events(&client_factory, &runtime);
     test_multi_reader_multi_segments_tail_read(&client_factory, &runtime);
-    handle.block_on(test_read_api(&client_factory));
-    handle.block_on(test_stream_scaling(&client_factory));
-    handle.block_on(test_release_segment(&client_factory));
-    handle.block_on(test_release_segment_at(&client_factory));
+    runtime.block_on(test_read_api(&client_factory));
+    runtime.block_on(test_stream_scaling(&client_factory));
+    runtime.block_on(test_release_segment(&client_factory));
+    runtime.block_on(test_release_segment_at(&client_factory));
     test_multiple_readers(&client_factory);
     test_reader_offline(&client_factory);
     test_segment_rebalance(&client_factory);
@@ -98,7 +97,7 @@ fn test_read_large_events(client_factory: &ClientFactory, rt: &Runtime) {
     assert_eq!(event_count, NUM_EVENTS);
 }
 
-fn test_multi_reader_multi_segments_tail_read(client_factory: &ClientFactory, rt: &Handle) {
+fn test_multi_reader_multi_segments_tail_read(client_factory: &ClientFactory, rt: &Runtime) {
     let scope_name = Scope::from("testMultiReaderMultiSegmentsTailRead".to_owned());
     let stream_name = Stream::from("testMultiReaderMultiSegmentsTailRead".to_owned());
 

--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::sync::{mpsc, Mutex};
-use tokio::time::delay_for;
+use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
 pub type ReaderErrorWithOffset = (ReaderError, i64);
@@ -511,51 +511,51 @@ impl EventReader {
     ///
     pub async fn acquire_segment(&mut self) -> Option<SegmentSlice> {
         info!("acquiring segment for reader {}", self.id);
-        loop {
-            // Check if newer segments should be acquired.
-            if self.meta.last_segment_acquire.elapsed() > REBALANCE_INTERVAL {
-                info!("need to rebalance segments across readers");
-                // Assign newer segments to this reader if available.
-                if let Some(new_segments) = self.assign_segments_to_reader().await {
-                    // fetch current segments.
-                    let current_segments = self
-                        .rg_state
-                        .lock()
-                        .await
-                        .get_segments_for_reader(&self.id)
-                        .await
-                        .expect("Read segments");
-                    let new_segments: HashSet<(ScopedSegment, Offset)> = current_segments
-                        .into_iter()
-                        .filter(|(seg, _off)| new_segments.contains(seg))
-                        .collect();
-                    debug!("segments which can be read next are {:?}", new_segments);
-                    // Initiate segment reads to the newer segments.
-                    self.initiate_segment_reads(new_segments);
-                    self.meta.last_segment_acquire = Instant::now();
-                }
+        // Check if newer segments should be acquired.
+        if self.meta.last_segment_acquire.elapsed() > REBALANCE_INTERVAL {
+            info!("need to rebalance segments across readers");
+            // Assign newer segments to this reader if available.
+            if let Some(new_segments) = self.assign_segments_to_reader().await {
+                // fetch current segments.
+                let current_segments = self
+                    .rg_state
+                    .lock()
+                    .await
+                    .get_segments_for_reader(&self.id)
+                    .await
+                    .expect("Read segments");
+                let new_segments: HashSet<(ScopedSegment, Offset)> = current_segments
+                    .into_iter()
+                    .filter(|(seg, _off)| new_segments.contains(seg))
+                    .collect();
+                debug!("segments which can be read next are {:?}", new_segments);
+                // Initiate segment reads to the newer segments.
+                self.initiate_segment_reads(new_segments);
+                self.meta.last_segment_acquire = Instant::now();
             }
-            // Check if any of the segments already has event data and return it.
-            if let Some(segment_with_data) = self.meta.get_segment_id_with_data() {
-                info!("segment {} has data ready to read", segment_with_data);
-                let slice_meta = self.meta.slices.remove(&segment_with_data).unwrap();
-                let segment = ScopedSegment::from(slice_meta.scoped_segment.as_str());
-                // Create an one-shot channel to receive SegmentSlice return.
-                let (slice_return_tx, slice_return_rx) = oneshot::channel();
-                self.meta.add_slice_release_receiver(segment, slice_return_rx);
+        }
+        // Check if any of the segments already has event data and return it.
+        if let Some(segment_with_data) = self.meta.get_segment_id_with_data() {
+            info!("segment {} has data ready to read", segment_with_data);
+            let slice_meta = self.meta.slices.remove(&segment_with_data).unwrap();
+            let segment = ScopedSegment::from(slice_meta.scoped_segment.as_str());
+            // Create an one-shot channel to receive SegmentSlice return.
+            let (slice_return_tx, slice_return_rx) = oneshot::channel();
+            self.meta.add_slice_release_receiver(segment, slice_return_rx);
 
-                info!(
-                    "segment slice for {:?} is ready for consumption by reader {}",
-                    slice_meta.scoped_segment, self.id,
-                );
-                self.meta
-                    .slices_dished_out
-                    .insert(segment_with_data, slice_meta.read_offset);
-                return Some(SegmentSlice {
-                    meta: slice_meta,
-                    slice_return_tx: Some(slice_return_tx),
-                });
-            } else if let Ok(read_result) = self.rx.try_recv() {
+            info!(
+                "segment slice for {:?} is ready for consumption by reader {}",
+                slice_meta.scoped_segment, self.id,
+            );
+            self.meta
+                .slices_dished_out
+                .insert(segment_with_data, slice_meta.read_offset);
+            Some(SegmentSlice {
+                meta: slice_meta,
+                slice_return_tx: Some(slice_return_tx),
+            })
+        } else if let Ok(option) = timeout(Duration::from_millis(1000), self.rx.recv()).await {
+            if let Some(read_result) = option {
                 match read_result {
                     // received segment data
                     Ok(data) => {
@@ -566,7 +566,7 @@ impl EventReader {
                                 != slice_meta.read_offset + slice_meta.segment_data.value.len() as i64
                             {
                                 info!("Data from an invalid offset {:?} observed. Expected offset {:?}. Ignoring this data", data.offset_in_segment, slice_meta.read_offset);
-                                return None;
+                                None
                             } else {
                                 // add received data to Segment slice.
                                 EventReader::add_data_to_segment_slice(data, &mut slice_meta);
@@ -584,10 +584,10 @@ impl EventReader {
                                     slice_meta.scoped_segment, self.id,
                                 );
 
-                                return Some(SegmentSlice {
+                                Some(SegmentSlice {
                                     meta: slice_meta,
                                     slice_return_tx: Some(slice_return_tx),
-                                });
+                                })
                             }
                         } else {
                             //None is sent if the the segment is released from the reader.
@@ -613,17 +613,20 @@ impl EventReader {
                             }
                         }
                         debug!("segment Slice meta {:?}", self.meta.slices);
-                        return None;
+                        None
                     }
                 }
             } else {
-                info!(
-                    "reader {} owns {} slices but none is ready to read",
-                    self.id,
-                    self.meta.slices.len()
-                );
-                delay_for(Duration::from_millis(100)).await;
+                warn!("error getting updates from segment slice for reader {}", self.id);
+                None
             }
+        } else {
+            info!(
+                "reader {} owns {} slices but none is ready to read",
+                self.id,
+                self.meta.slices.len()
+            );
+            None
         }
     }
 

--- a/src/segment_slice.rs
+++ b/src/segment_slice.rs
@@ -13,6 +13,7 @@ use crate::event_reader::SegmentReadResult;
 use crate::segment_reader::AsyncSegmentReader;
 use crate::segment_reader::ReaderError::SegmentSealed;
 use bytes::{Buf, BufMut, BytesMut};
+use core::fmt;
 use pravega_client_retry::retry_result::Retryable;
 use pravega_client_shared::ScopedSegment;
 use pravega_wire_protocol::commands::{Command, EventCommand, TYPE_PLUS_LENGTH_SIZE};
@@ -40,10 +41,16 @@ pub struct SegmentSlice {
     pub(crate) slice_return_tx: Option<oneshot::Sender<Option<SliceMetadata>>>,
 }
 
+impl fmt::Debug for SegmentSlice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SegmentSlice").field("meta", &self.meta).finish()
+    }
+}
+
 ///
 /// This holds the SegmentSlice metadata. This meta is persisted by the EventReader.
 ///
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SliceMetadata {
     pub start_offset: i64,
     pub scoped_segment: String,
@@ -52,6 +59,19 @@ pub struct SliceMetadata {
     pub end_offset: i64,
     pub(crate) segment_data: SegmentDataBuffer,
     pub partial_data_present: bool,
+}
+
+impl fmt::Debug for SliceMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SliceMetadata")
+            .field("start_offset", &self.start_offset)
+            .field("scoped_segment", &self.scoped_segment)
+            .field("last_event_offset", &self.last_event_offset)
+            .field("read_offset", &self.read_offset)
+            .field("end_offset", &self.end_offset)
+            .field("partial_data_present", &self.partial_data_present)
+            .finish()
+    }
 }
 
 ///


### PR DESCRIPTION
**Change log description**  
Change `recv` to `try_recv` in `acquire_segment` method.

**Purpose of the change**  
Fix #228 

**What the code does**  
`recv` will block forever if there is no slice for that reader. Use `try_recv` to let method return and caller can re-enter the method to acquire new segments.

**How to verify it**  
Test should pass
