### PR TITLE
Issue 225: Implement list streams controller API

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -44,6 +44,7 @@ jobs:
         run: tox -c bindings/tox.ini
       - name: Upload Pravega standalone logs
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: pravega-standalone-log
           path: pravega.log

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - master
-      - enable-tox
 
 name: pythontest
 

--- a/controller-client/Cargo.toml
+++ b/controller-client/Cargo.toml
@@ -32,6 +32,7 @@ im = "15"
 tracing = "0.1"
 jsonwebtoken = "7"
 serde = {version = "1.0", features = ["derive"] }
+futures = "0.3"
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -26,7 +26,6 @@
 #![allow(clippy::multiple_crate_versions)]
 #![allow(dead_code)]
 #![allow(clippy::similar_names)]
-#![allow(clippy::upper_case_acronyms)]
 
 use std::result::Result as StdResult;
 use std::time::{Duration, Instant};

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -1542,9 +1542,9 @@ mod test {
 
         // test list streams
         let res = rt
-            .block_on(controller.list_streams(&scope))
+            .block_on(controller.list_streams(&scope, &String::from("")))
             .expect("list streams");
-        assert_eq!(res, vec!["s1".to_string()])
+        assert_eq!(res, Some((vec!["s1".to_string()], String::from("123"))))
     }
 
     #[derive(Default)]

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::multiple_crate_versions)]
 #![allow(dead_code)]
 #![allow(clippy::similar_names)]
+#![allow(clippy::upper_case_acronyms)]
 
 use std::result::Result as StdResult;
 use std::time::{Duration, Instant};

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -133,8 +133,7 @@ pub trait ControllerClient: Send + Sync {
      * API to list streams under a given scope and continuation token.
      * Use the pravega_controller_client::paginator::list_streams to paginate over all the streams.
      */
-    async fn list_streams(&self, scope: &Scope, token: &String)
-        -> ResultRetry<Option<(Vec<String>, String)>>;
+    async fn list_streams(&self, scope: &Scope, token: &str) -> ResultRetry<Option<(Vec<String>, String)>>;
 
     /**
      * API to delete a scope. Note that a scope can only be deleted in the case is it empty. If
@@ -332,11 +331,7 @@ impl ControllerClient for ControllerClientImpl {
         )
     }
 
-    async fn list_streams(
-        &self,
-        scope: &Scope,
-        token: &String,
-    ) -> ResultRetry<Option<(Vec<String>, String)>> {
+    async fn list_streams(&self, scope: &Scope, token: &str) -> ResultRetry<Option<(Vec<String>, String)>> {
         wrap_with_async_retry!(
             self.config.retry_policy.max_tries(MAX_RETRIES),
             self.call_list_streams(scope, token)
@@ -617,11 +612,7 @@ impl ControllerClientImpl {
         })
     }
 
-    async fn call_list_streams(
-        &self,
-        scope: &Scope,
-        token: &String,
-    ) -> Result<Option<(Vec<String>, String)>> {
+    async fn call_list_streams(&self, scope: &Scope, token: &str) -> Result<Option<(Vec<String>, String)>> {
         let operation_name = "ListStreams";
         let request: StreamsInScopeRequest = StreamsInScopeRequest {
             scope: Some(ScopeInfo::from(scope)),

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -78,8 +78,8 @@ impl ControllerClient for MockController {
     async fn list_streams(
         &self,
         scope: &Scope,
-        _token: &str,
-    ) -> Result<Option<(Vec<String>, String)>, RetryError<ControllerError>> {
+        _token: &CToken,
+    ) -> Result<Option<(Vec<ScopedStream>, CToken)>, RetryError<ControllerError>> {
         let map_guard = self.created_scopes.read().await;
         let streams_set = map_guard.get(&scope.name).ok_or(RetryError {
             error: ControllerError::OperationError {
@@ -92,9 +92,9 @@ impl ControllerClient for MockController {
         })?;
         let mut result = Vec::new();
         for stream in streams_set {
-            result.push(stream.stream.name.clone())
+            result.push(stream.clone())
         }
-        Ok(Some((result, String::from(""))))
+        Ok(Some((result, CToken::from("mock_token"))))
     }
 
     async fn delete_scope(&self, scope: &Scope) -> Result<bool, RetryError<ControllerError>> {

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -78,7 +78,7 @@ impl ControllerClient for MockController {
     async fn list_streams(
         &self,
         scope: &Scope,
-        _token: &String,
+        _token: &str,
     ) -> Result<Option<(Vec<String>, String)>, RetryError<ControllerError>> {
         let map_guard = self.created_scopes.read().await;
         let streams_set = map_guard.get(&scope.name).ok_or(RetryError {

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -75,7 +75,11 @@ impl ControllerClient for MockController {
         Ok(true)
     }
 
-    async fn list_streams(&self, scope: &Scope) -> Result<Vec<String>, RetryError<ControllerError>> {
+    async fn list_streams(
+        &self,
+        scope: &Scope,
+        _token: &String,
+    ) -> Result<Option<(Vec<String>, String)>, RetryError<ControllerError>> {
         let map_guard = self.created_scopes.read().await;
         let streams_set = map_guard.get(&scope.name).ok_or(RetryError {
             error: ControllerError::OperationError {
@@ -90,7 +94,7 @@ impl ControllerClient for MockController {
         for stream in streams_set {
             result.push(stream.stream.name.clone())
         }
-        Ok(result)
+        Ok(Some((result, String::from(""))))
     }
 
     async fn delete_scope(&self, scope: &Scope) -> Result<bool, RetryError<ControllerError>> {

--- a/controller-client/src/model_helper.rs
+++ b/controller-client/src/model_helper.rs
@@ -71,6 +71,23 @@ impl<'a> From<&'a ScopedStream> for StreamInfo {
     }
 }
 
+impl From<StreamInfo> for ScopedStream {
+    fn from(value: StreamInfo) -> ScopedStream {
+        ScopedStream {
+            scope: Scope::from(value.scope),
+            stream: Stream::from(value.stream),
+        }
+    }
+}
+
+impl<'a> From<&'a CToken> for ContinuationToken {
+    fn from(t: &'a CToken) -> ContinuationToken {
+        ContinuationToken {
+            token: t.token.to_owned(),
+        }
+    }
+}
+
 impl<'a> From<&'a Scope> for ScopeInfo {
     fn from(value: &'a Scope) -> ScopeInfo {
         ScopeInfo {

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -22,9 +22,18 @@ use tracing::info;
 ///
 /// The below snippets show case the example uses.
 /// Sample 1:
-///```
+///```ignore
+/// # futures::executor::block_on(async {
 /// use pravega_client_shared::Scope;
 /// use pravega_controller_client::paginator::list_streams;
+/// use pravega_client::client_factory::ClientFactory;
+/// use pravega_client_config::ClientConfigBuilder;
+/// use pravega_client_config::MOCK_CONTROLLER_URI;
+///     let config = ClientConfigBuilder::default()
+///         .controller_uri(MOCK_CONTROLLER_URI)
+///         .build()
+///         .expect("creating config");
+///     let controller_client = ClientFactory::new(config).get_controller_client();
 ///     let stream = list_streams(
 ///         Scope {
 ///             name: "testScope".to_string(),
@@ -33,12 +42,23 @@ use tracing::info;
 ///     );
 ///     // collect all the Streams in a single vector
 ///     let stream_list:Vec<String> = stream.map(|str| str.unwrap()).collect::<Vec<String>>().await;
+///  # });
 /// ```
 ///
 /// Sample 2:
-/// ```
+/// ```ignore
+/// # futures::executor::block_on(async {
 /// use pravega_client_shared::Scope;
 /// use pravega_controller_client::paginator::list_streams;
+/// use pravega_client::client_factory::ClientFactory;
+/// use pravega_client_config::ClientConfigBuilder;
+/// use pravega_client_config::MOCK_CONTROLLER_URI;
+/// use futures::StreamExt;
+///     let config = ClientConfigBuilder::default()
+///         .controller_uri(MOCK_CONTROLLER_URI)
+///         .build()
+///         .expect("creating config");
+///     let controller_client = ClientFactory::new(config).get_controller_client();
 ///     let mut stream = list_streams(
 ///         Scope {
 ///             name: "testScope".to_string(),
@@ -48,6 +68,7 @@ use tracing::info;
 /// let pravega_stream_1 = stream.next().await;
 /// let pravega_stream_2 = stream.next().await;
 /// // A None is returned at the end of the stream.
+///  # });
 /// ```
 ///
 pub fn list_streams(

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+use crate::{ControllerClient, ControllerError, ResultRetry};
+use futures::prelude::*;
+use futures::stream::{self};
+use pravega_client_retry::retry_result::RetryError;
+use pravega_client_shared::Scope;
+use std::vec::IntoIter;
+use tracing::{debug, error, info, warn};
+
+pub fn list_streams(
+    scope: Scope,
+    client: &dyn ControllerClient,
+) -> impl Stream<Item = Result<String, RetryError<ControllerError>>> + '_ {
+    struct State {
+        streams: IntoIter<String>,
+        scope: Scope,
+        token: String,
+    };
+
+    // Initial state with an empty Continuation token.
+    stream::unfold(
+        State {
+            streams: Vec::new().into_iter(),
+            scope: scope.clone(),
+            token: String::from(""),
+        },
+        move |mut state| async move {
+            if let Some(element) = state.streams.next() {
+                Some((Ok(element), state))
+            } else {
+                // execute a request to the controller.
+                let res: ResultRetry<Option<(Vec<String>, String)>> =
+                    client.list_streams(&state.scope, &state.token).await;
+                match res {
+                    Ok(None) => None,
+                    Ok(Some((list, ct))) => {
+                        // create a consuming iterator
+                        let mut stream_iter = list.into_iter();
+                        Some((
+                            Ok(stream_iter.next()?),
+                            State {
+                                streams: stream_iter,
+                                scope: state.scope.clone(),
+                                token: ct,
+                            },
+                        ))
+                    }
+
+                    Err(e) => Some((Err(e), state)),
+                }
+            }
+        },
+    )
+}
+// impl Paginator<'_> {
+//     // pub fn list_streams(&self, scope: &Scope) -> impl Stream<Item = String> {
+//     //     struct State {
+//     //         scope: Scope,
+//     //         token: String,
+//     //     };
+//     //
+//     //     // Initial state with an empty Continuation token.
+//     //     let stream_result = stream::unfold(
+//     //         State {
+//     //             scope: scope.clone(),
+//     //             token: String::from(""),
+//     //         },
+//     //         |state| async move {
+//     //             let res: ResultRetry<Option<(Vec<String>, String)>> =
+//     //                 self.client.list_streams(scope, &state.token).await;
+//     //             match res {
+//     //                 Ok(None) => None,
+//     //                 Ok(Some((list, ct))) => Some((
+//     //                     stream::iter(list),
+//     //                     State {
+//     //                         scope: state.scope,
+//     //                         token: ct,
+//     //                     },
+//     //                 )),
+//     //                 _ => None,
+//     //             }
+//     //         },
+//     //     )
+//     //     .flatten();
+//     //     stream_result
+//     // }
+//     // pub fn list_streams(&self, scope: &Scope) -> impl Stream<Item = Result<String, ControllerError>> {
+//     //     struct State {
+//     //         scope: Scope,
+//     //         list: Vec<String>,
+//     //         token: String,
+//     //     };
+//     //
+//     //     // Initial state with an empty Continuation token.
+//     //
+//     //     let stream_result = stream::unfold(
+//     //         State {
+//     //             scope: scope.clone(),
+//     //             list: vec![],
+//     //             token: String::from(""),
+//     //         },
+//     //         |mut state| async move {
+//     //             if !state.list.is_empty() {
+//     //                 // Return from already fetched stream list.
+//     //                 Some((Ok(state.list.pop().unwrap()), state))
+//     //             } else {
+//     //                 // The list is empty, try fetching it from the controller using the previous continuation token.
+//     //
+//     //                 debug!(
+//     //                     "Triggering a request to the controller to list streams for scope {}",
+//     //                     &state.scope
+//     //                 );
+//     //                 let res: ResultRetry<Option<(Vec<String>, String)>> =
+//     //                     self.client.list_streams(&state.scope, &state.token).await;
+//     //
+//     //                 match res {
+//     //                     Ok(None) => None,
+//     //                     Ok(Some((list, token))) => {
+//     //                         if list.is_empty() {
+//     //                             // Empty result from the controller implies no further streams present.
+//     //                             None
+//     //                         } else {
+//     //                             // update state with the new set of streams.
+//     //                             state.list.extend_from_slice(list.as_slice());
+//     //                             state.token = token;
+//     //                             Some((Ok(state.list.pop().unwrap()), state))
+//     //                         }
+//     //                     }
+//     //                     Err(err) => {
+//     //                         error!(
+//     //                             "Error while listing streams under scope {}, {:?}",
+//     //                             &state.scope, err
+//     //                         );
+//     //                         None
+//     //                     }
+//     //                 }
+//     //             }
+//     //         },
+//     //     );
+//     //     stream_result
+//     // }
+// }

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -64,7 +64,7 @@ pub fn list_streams(
     stream::unfold(
         State {
             streams: Vec::new().into_iter(),
-            scope: scope.clone(),
+            scope: scope,
             token: String::from(""),
         },
         move |mut state| async move {

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -64,7 +64,7 @@ pub fn list_streams(
     stream::unfold(
         State {
             streams: Vec::new().into_iter(),
-            scope: scope,
+            scope,
             token: String::from(""),
         },
         move |mut state| async move {

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -58,7 +58,7 @@ pub fn list_streams(
         streams: IntoIter<String>,
         scope: Scope,
         token: String,
-    };
+    }
 
     // Initial state with an empty Continuation token.
     stream::unfold(

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -189,6 +189,31 @@ impl From<&str> for ScopedStream {
     }
 }
 
+///
+/// This represents the continuation token returned by the controller
+/// as part of the list streams grpc API.
+///
+#[derive(new, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CToken {
+    pub token: String,
+}
+
+impl CToken {
+    pub fn empty() -> CToken {
+        CToken {
+            token: String::from(""),
+        }
+    }
+}
+
+impl From<&str> for CToken {
+    fn from(string: &str) -> Self {
+        CToken {
+            token: string.to_string(),
+        }
+    }
+}
+
 #[derive(new, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScopedSegment {
     pub scope: Scope,


### PR DESCRIPTION
**Change log description**  
- Enable List Streams Controller API on the Rust Client.
- Create a Paginator utility which returns a `impl Stream<Item = Result<String, RetryError<ControllerError>>>`  to handle huge stream lists with pagination.
- Enable List Streams option in the Controller CLI

**Purpose of the change**  
Fixes #225 

**What the code does**  
- Enable controller api list streams which returns the streams for the provided scope and continuationToken.
```rust
async fn list_streams(&self, scope: &Scope, token: &str) -> ResultRetry<Option<(Vec<String>, String)>>;
```
- A paginator helper which returns an `impl Stream`  thereby lazily fetch the next page of streams from Pravega
```rust
pub fn list_streams(
    scope: Scope,
    client: &dyn ControllerClient,
) -> impl Stream<Item = Result<String, RetryError<ControllerError>>> 
```
This uses the `futures::stream::unfold` to fetch streams under a given scope.
- Example usage 
```rust
// Sample 1
use pravega_client_shared::Scope;
use pravega_controller_client::paginator::list_streams;
    let stream = list_streams(
        Scope {
            name: "testScope".to_string(),
        },
        controller_client,
    );
    // collect all the Streams in a single vector
    let stream_list:Vec<String> = stream.map(|str| str.unwrap()).collect::<Vec<String>>().await;

// Sample 2
use pravega_client_shared::Scope;
use pravega_controller_client::paginator::list_streams;
    let mut stream = list_streams(
        Scope {
             name: "testScope".to_string(),
         },
        controller_client,
    );
let pravega_stream_1 = stream.next().await;
let pravega_stream_2 = stream.next().await;
// A None is returned at the end of the stream.
```

CLI Option for list-streams.
```
osboxes@osboxes:~/$ ./controller-cli list-streams --help
controller-cli-list-streams 0.1.0
List Streams under a scope

USAGE:
    controller-cli list-streams <scope-name>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <scope-name>    Scope Name

```

**How to verify it**  
The existing and newly added tests should pass. 
Verified it for a huge list of streams against standalone.
