### PR TITLE
Issue 245: Async token refresh

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -182,8 +182,8 @@ mod tests {
         assert_eq!(config.retry_policy(), RetryWithBackoff::default());
     }
 
-    #[test]
-    fn test_extract_credentials() {
+    #[tokio::test]
+    async fn test_extract_credentials() {
         // test empty env
         let config = ClientConfigBuilder::default()
             .controller_uri("127.0.0.2:9091".to_string())
@@ -193,7 +193,7 @@ mod tests {
         let token = encode(":");
 
         assert_eq!(
-            config.credentials.get_request_metadata(),
+            config.credentials.get_request_metadata().await,
             format!("{} {}", "Basic", token)
         );
 
@@ -209,7 +209,7 @@ mod tests {
 
         let token = encode("hello:12345");
         assert_eq!(
-            config.credentials.get_request_metadata(),
+            config.credentials.get_request_metadata().await,
             format!("{} {}", "Basic", token)
         );
 
@@ -220,7 +220,7 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(
-            config.credentials.get_request_metadata(),
+            config.credentials.get_request_metadata().await,
             format!("{} {}", "Basic", "ABCDE")
         );
         env::remove_var("pravega_client_auth_method");

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -514,16 +514,7 @@ impl ControllerClientImpl {
     pub fn new(config: ClientConfig, rt: &Runtime) -> Self {
         // actual connection is established lazily.
         let ch = rt.block_on(get_channel(&config));
-        let client = if config.is_auth_enabled {
-            let token = rt.block_on(config.credentials.get_request_metadata());
-            let token = MetadataValue::from_str(&token).expect("convert to metadata value");
-            ControllerServiceClient::with_interceptor(ch, move |mut req: Request<()>| {
-                req.metadata_mut().insert(AUTHORIZATION, token.clone());
-                Ok(req)
-            })
-        } else {
-            ControllerServiceClient::new(ch)
-        };
+        let client = ControllerServiceClient::new(ch);
 
         ControllerClientImpl {
             config,
@@ -538,16 +529,7 @@ impl ControllerClientImpl {
     pub async fn reset(&self) {
         let ch = get_channel(&self.config).await;
         let mut x = self.channel.write().await;
-        if self.config.is_auth_enabled {
-            let token = self.config.credentials.get_request_metadata().await;
-            let token = MetadataValue::from_str(&token).expect("convert to metadata value");
-            *x = ControllerServiceClient::with_interceptor(ch, move |mut req: Request<()>| {
-                req.metadata_mut().insert(AUTHORIZATION, token.clone());
-                Ok(req)
-            });
-        } else {
-            *x = ControllerServiceClient::new(ch);
-        }
+        *x = ControllerServiceClient::new(ch);
     }
 
     ///

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -561,6 +561,7 @@ impl ControllerClientImpl {
             // get_request_metadata internally checks if token expired before sending request to the server,
             // race condition might happen here but eventually only one request will be sent.
             let mut x = self.channel.write().await;
+            let ch = get_channel(&self.config).await;
             let token = self.config.credentials.get_request_metadata().await;
             let token = MetadataValue::from_str(&token).expect("convert to metadata value");
             *x = ControllerServiceClient::with_interceptor(ch, move |mut req: Request<()>| {


### PR DESCRIPTION
**Change log description**  
Currently token refresh is using a Runtime which makes it impossible to work in a async context. Use async way to refresh the token instead.

**Purpose of the change**  
Fix #245 

**What the code does**  
Use async way to refresh token

