### PR TITLE
Issue 200: Drop on EventReader should automatically invoke reader offline API.

### DIFF
--- a/python_binding/tests/pravega_reader_test.py
+++ b/python_binding/tests/pravega_reader_test.py
@@ -80,7 +80,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
         for i in range(100):
             w1.write_event("data")
 
-        reader_group = stream_manager.create_reader_group("rg-multi" + suffix, scope, stream);
+        reader_group = stream_manager.create_reader_group("rg-multi" + suffix, scope, stream)
         r1 = reader_group.create_reader("r1")
         slice1 = await r1.get_segment_slice_async()
         print(slice1)

--- a/python_binding/tests/pravega_reader_test.py
+++ b/python_binding/tests/pravega_reader_test.py
@@ -55,7 +55,6 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             print(event.data())
             self.assertEqual(b'test event', event.data(), "Invalid event data")
         self.assertEqual(count, 2, "Two events are expected")
-        r1.reader_offline()
 
     # This test verifies data reading a Pravega stream with multiple readers.
     # It also invokes release Segment after consuming the first segment slice and marks the first
@@ -104,7 +103,6 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
 
         print("Number of events read after consuming slice2 ", count)
         self.assertEqual(count, 100, "100 events are expected")
-        r2.reader_offline()
 
     # This test verifies data reading a Pravega stream with multiple readers.
     # It also invokes release Segment after consuming part of the first segment slice and marks the first
@@ -160,7 +158,6 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             print("Number of events read after consuming slice3 ", count)
 
         self.assertEqual(count, 100, "100 events are expected")
-        r2.reader_offline()
 
     # This test verifies reading large events from a Pravega stream
     async def test_largeEvents(self):
@@ -193,4 +190,3 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             for event in segment_slice:
                 count += 1
             r1.release_segment(segment_slice)
-        r1.reader_offline()

--- a/python_binding/tests/pravega_reader_test.py
+++ b/python_binding/tests/pravega_reader_test.py
@@ -55,6 +55,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             print(event.data())
             self.assertEqual(b'test event', event.data(), "Invalid event data")
         self.assertEqual(count, 2, "Two events are expected")
+        r1.reader_offline()
 
     # This test verifies data reading a Pravega stream with multiple readers.
     # It also invokes release Segment after consuming the first segment slice and marks the first
@@ -103,6 +104,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
 
         print("Number of events read after consuming slice2 ", count)
         self.assertEqual(count, 100, "100 events are expected")
+        r2.reader_offline()
 
     # This test verifies data reading a Pravega stream with multiple readers.
     # It also invokes release Segment after consuming part of the first segment slice and marks the first
@@ -158,6 +160,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             print("Number of events read after consuming slice3 ", count)
 
         self.assertEqual(count, 100, "100 events are expected")
+        r2.reader_offline()
 
     # This test verifies reading large events from a Pravega stream
     async def test_largeEvents(self):
@@ -190,3 +193,4 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
             for event in segment_slice:
                 count += 1
             r1.release_segment(segment_slice)
+        r1.reader_offline()

--- a/python_binding/tox.ini
+++ b/python_binding/tox.ini
@@ -8,7 +8,7 @@ requires = tox-pyo3
 [testenv]
 pyo3 = True
 setenv =
-    RUST_LOG=info
+    RUST_LOG=debug
 deps =
     pytest
     pytest-timeout

--- a/python_binding/tox.ini
+++ b/python_binding/tox.ini
@@ -7,6 +7,8 @@ requires = tox-pyo3
 
 [testenv]
 pyo3 = True
+setenv =
+    RUST_LOG=info
 deps =
     pytest
     pytest-timeout

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -128,7 +128,7 @@ pub struct Reader {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Segment {
     pub number: i64,
     pub tx_id: Option<TxId>,
@@ -157,6 +157,23 @@ impl Segment {
 
     pub fn is_transaction_segment(&self) -> bool {
         self.tx_id.is_some()
+    }
+
+    pub fn get_epoch(&self) -> i32 {
+        (self.number >> 32) as i32
+    }
+
+    pub fn get_segment_number(&self) -> i32 {
+        self.number as i32
+    }
+}
+
+impl fmt::Debug for Segment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Segment")
+            .field("segment", &self.get_segment_number())
+            .field("epoch", &self.get_epoch())
+            .finish()
     }
 }
 

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -1177,6 +1177,7 @@ mod tests {
         rg_mock
             .expect_compute_segments_to_acquire_or_release()
             .return_const(0 as isize);
+        rg_mock.expect_remove_reader().return_once(move |_, _| Ok(()));
         // create a new Event Reader with the segment slice data.
         let mut reader = EventReader::init_event_reader(
             Arc::new(Mutex::new(rg_mock)),
@@ -1213,7 +1214,6 @@ mod tests {
                 break;
             }
         }
-        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1245,6 +1245,7 @@ mod tests {
             .expect_compute_segments_to_acquire_or_release()
             .with(predicate::eq(Reader::from("r1".to_string())))
             .return_const(1 as isize);
+        rg_mock.expect_remove_reader().return_once(move |_, _| Ok(()));
 
         // mock rg_state.assign_segment_to_reader
         let res: Result<Option<ScopedSegment>, ReaderGroupStateError> =
@@ -1308,7 +1309,6 @@ mod tests {
             }
         }
         assert_eq!(event_count, NUM_EVENTS + NUM_EVENTS);
-        cf.runtime().block_on(reader.reader_offline());
     }
 
     // This test verifies an EventReader reading from a stream where both the segments are sending data.
@@ -1348,6 +1348,7 @@ mod tests {
         rg_mock
             .expect_compute_segments_to_acquire_or_release()
             .return_const(0 as isize);
+        rg_mock.expect_remove_reader().return_once(move |_, _| Ok(()));
         // create a new Event Reader with the segment slice data.
         let mut reader = EventReader::init_event_reader(
             Arc::new(Mutex::new(rg_mock)),
@@ -1389,7 +1390,6 @@ mod tests {
                 break;
             }
         }
-        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1421,7 +1421,7 @@ mod tests {
         rg_mock
             .expect_compute_segments_to_acquire_or_release()
             .return_const(0 as isize);
-
+        rg_mock.expect_remove_reader().return_once(move |_, _| Ok(()));
         // create a new Event Reader with the segment slice data.
         let mut reader = EventReader::init_event_reader(
             Arc::new(Mutex::new(rg_mock)),
@@ -1458,7 +1458,6 @@ mod tests {
         assert_eq!(event.value.len(), 2);
         assert!(is_all_same(event.value.as_slice()), "Event has been corrupted");
         assert_eq!(event.offset_in_segment, 8 + 1); // first event.
-        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1493,6 +1492,7 @@ mod tests {
         rg_mock
             .expect_compute_segments_to_acquire_or_release()
             .return_const(0 as isize);
+        rg_mock.expect_remove_reader().return_once(move |_, _| Ok(()));
         // create a new Event Reader with the segment slice data.
         let mut reader = EventReader::init_event_reader(
             Arc::new(Mutex::new(rg_mock)),
@@ -1541,7 +1541,6 @@ mod tests {
         assert_eq!(event.value.len(), 1);
         assert!(is_all_same(event.value.as_slice()), "Event has been corrupted");
         assert_eq!(event.offset_in_segment, 0); // first event.
-        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[tokio::test]

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -1213,6 +1213,7 @@ mod tests {
                 break;
             }
         }
+        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1307,6 +1308,7 @@ mod tests {
             }
         }
         assert_eq!(event_count, NUM_EVENTS + NUM_EVENTS);
+        cf.runtime().block_on(reader.reader_offline());
     }
 
     // This test verifies an EventReader reading from a stream where both the segments are sending data.
@@ -1387,6 +1389,7 @@ mod tests {
                 break;
             }
         }
+        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1455,6 +1458,7 @@ mod tests {
         assert_eq!(event.value.len(), 2);
         assert!(is_all_same(event.value.as_slice()), "Event has been corrupted");
         assert_eq!(event.offset_in_segment, 8 + 1); // first event.
+        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[test]
@@ -1537,6 +1541,7 @@ mod tests {
         assert_eq!(event.value.len(), 1);
         assert!(is_all_same(event.value.as_slice()), "Event has been corrupted");
         assert_eq!(event.offset_in_segment, 0); // first event.
+        cf.runtime().block_on(reader.reader_offline());
     }
 
     #[tokio::test]

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -107,6 +107,15 @@ pub struct EventReader {
     rg_state: Arc<Mutex<ReaderGroupState>>,
 }
 
+impl Drop for EventReader {
+    /// Destructor for reader invoked. This will automatically invoke reader_offline().
+    fn drop(&mut self) {
+        info!("reader {} is dropped", self.id);
+        let runtime = self.factory.runtime().handle().clone();
+        runtime.block_on(self.reader_offline());
+    }
+}
+
 impl EventReader {
     /// Initialize the reader. This fetches the assigned segments from the TableSynchronizer and
     /// spawns background tasks to start reads from those Segments.


### PR DESCRIPTION
**Change log description**  
Drop on EventReader should invoke readerOffline.

**Purpose of the change**  
Fixes #200 

**What the code does**  
Drop on EventReader should invoke `reader_offline()`.

This is useful in scenarios where the Python user forgets to invoke reader offline. A scenario described in #257 is one instance of this.

With this change, `reader_offline()` is automatically invoked when the object is destructed.
```
In [11]: r1=rg.create_reader("r1")
May 14 18:54:41.627  INFO pravega_client::stream_reader_group: Creating reader "r1" under reader group "rg2"
May 14 18:54:41.627  INFO pravega_client::event::reader_group_state: Adding reader Reader { name: "r1" } to reader group

In [12]: r1=rg.create_reader("r2")
May 14 18:54:47.361  INFO pravega_client::stream_reader_group: Creating reader "r2" under reader group "rg2"
May 14 18:54:47.361  INFO pravega_client::event::reader_group_state: Adding reader Reader { name: "r2" } to reader group
May 14 18:54:47.369  INFO pravega_client::event::reader: putting reader r1 offline
```

**How to verify it**  
All the existing tests should continue to pass.
