### PR TITLE
Issue 262: support multiple segments in byte stream

### DIFF
--- a/integration_test/src/byte_reader_writer_tests.rs
+++ b/integration_test/src/byte_reader_writer_tests.rs
@@ -70,16 +70,19 @@ pub fn test_byte_stream(config: PravegaStandaloneServiceConfig) {
         client_factory.controller_client(),
         &scope_name,
         &stream_name,
-        1,
+        4,
     ));
-    let scoped_segment = ScopedSegment {
-        scope: scope_name,
-        stream: stream_name,
-        segment: Segment::from(0),
-    };
-    let mut writer = client_factory.create_byte_writer(scoped_segment.clone());
-    let mut reader = client_factory.create_byte_reader(scoped_segment);
-    test_write_and_read_with_workload(&mut writer, &mut reader);
+
+    for i in 0..4 {
+        let scoped_segment = ScopedSegment {
+            scope: scope_name.clone(),
+            stream: stream_name.clone(),
+            segment: Segment::from(i),
+        };
+        let mut writer = client_factory.create_byte_writer(scoped_segment.clone());
+        let mut reader = client_factory.create_byte_reader(scoped_segment);
+        test_write_and_read_with_workload(&mut writer, &mut reader);
+    }
 
     let scope_name = Scope::from("testScopeByteStreamConditionalAppend".to_owned());
     let stream_name = Stream::from("testStreamByteStreamConditionalAppend".to_owned());

--- a/src/event/transactional_writer.rs
+++ b/src/event/transactional_writer.rs
@@ -9,7 +9,7 @@
 //
 
 use crate::client_factory::ClientFactory;
-use crate::segment::event::{Incoming, PendingEvent};
+use crate::segment::event::{Incoming, PendingEvent, RoutingInfo};
 use crate::segment::reactor::Reactor;
 
 use pravega_client_auth::DelegationTokenProvider;
@@ -266,7 +266,8 @@ impl Transaction {
 
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(None, routing_key, event, None, tx) {
+        let routing_info = RoutingInfo::RoutingKey(routing_key);
+        if let Some(pending_event) = PendingEvent::with_header(routing_info, event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             if let Err(e) = self.sender.send((append_event, size)).await {
                 error!(

--- a/src/event/transactional_writer.rs
+++ b/src/event/transactional_writer.rs
@@ -266,7 +266,7 @@ impl Transaction {
 
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(routing_key, event, None, tx) {
+        if let Some(pending_event) = PendingEvent::with_header(None, routing_key, event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             if let Err(e) = self.sender.send((append_event, size)).await {
                 error!(

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -118,7 +118,7 @@ impl EventWriter {
     pub async fn write_event(&mut self, event: Vec<u8>) -> oneshot::Receiver<Result<(), Error>> {
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(None, event, None, tx) {
+        if let Some(pending_event) = PendingEvent::with_header(None, None, event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             self.writer_event_internal(append_event, size, rx).await
         } else {
@@ -136,7 +136,7 @@ impl EventWriter {
     ) -> oneshot::Receiver<Result<(), Error>> {
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(Some(routing_key), event, None, tx) {
+        if let Some(pending_event) = PendingEvent::with_header(None, Some(routing_key), event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             self.writer_event_internal(append_event, size, rx).await
         } else {

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -9,7 +9,7 @@
 //
 
 use crate::client_factory::ClientFactory;
-use crate::segment::event::{Incoming, PendingEvent};
+use crate::segment::event::{Incoming, PendingEvent, RoutingInfo};
 use crate::segment::reactor::Reactor;
 use crate::util::get_random_u128;
 
@@ -118,7 +118,8 @@ impl EventWriter {
     pub async fn write_event(&mut self, event: Vec<u8>) -> oneshot::Receiver<Result<(), Error>> {
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(None, None, event, None, tx) {
+        let routing_info = RoutingInfo::RoutingKey(None);
+        if let Some(pending_event) = PendingEvent::with_header(routing_info, event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             self.writer_event_internal(append_event, size, rx).await
         } else {
@@ -136,7 +137,8 @@ impl EventWriter {
     ) -> oneshot::Receiver<Result<(), Error>> {
         let size = event.len();
         let (tx, rx) = oneshot::channel();
-        if let Some(pending_event) = PendingEvent::with_header(None, Some(routing_key), event, None, tx) {
+        let routing_info = RoutingInfo::RoutingKey(Some(routing_key));
+        if let Some(pending_event) = PendingEvent::with_header(routing_info, event, None, tx) {
             let append_event = Incoming::AppendEvent(pending_event);
             self.writer_event_internal(append_event, size, rx).await
         } else {
@@ -176,25 +178,24 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use super::*;
-    use crate::segment::event::PendingEvent;
+    use crate::segment::event::{PendingEvent, RoutingInfo};
 
     #[test]
     fn test_pending_event() {
         // test with legal event size
         let (tx, _rx) = oneshot::channel();
         let data = vec![];
-        let routing_key = None;
+        let routing_info = RoutingInfo::Empty();
 
-        let event =
-            PendingEvent::without_header(None, routing_key, data, None, tx).expect("create pending event");
+        let event = PendingEvent::without_header(routing_info, data, None, tx).expect("create pending event");
         assert!(event.is_empty());
 
         // test with illegal event size
         let (tx, rx) = oneshot::channel();
         let data = vec![0; (PendingEvent::MAX_WRITE_SIZE + 1) as usize];
-        let routing_key = None;
+        let routing_info = RoutingInfo::Empty();
 
-        let event = PendingEvent::without_header(None, routing_key, data, None, tx);
+        let event = PendingEvent::without_header(routing_info, data, None, tx);
         assert!(event.is_none());
 
         let rt = Runtime::new().expect("get runtime");

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -185,7 +185,7 @@ mod tests {
         // test with legal event size
         let (tx, _rx) = oneshot::channel();
         let data = vec![];
-        let routing_info = RoutingInfo::Empty();
+        let routing_info = RoutingInfo::RoutingKey(None);
 
         let event = PendingEvent::without_header(routing_info, data, None, tx).expect("create pending event");
         assert!(event.is_empty());
@@ -193,7 +193,7 @@ mod tests {
         // test with illegal event size
         let (tx, rx) = oneshot::channel();
         let data = vec![0; (PendingEvent::MAX_WRITE_SIZE + 1) as usize];
-        let routing_info = RoutingInfo::Empty();
+        let routing_info = RoutingInfo::RoutingKey(None);
 
         let event = PendingEvent::without_header(routing_info, data, None, tx);
         assert!(event.is_none());

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -185,7 +185,8 @@ mod tests {
         let data = vec![];
         let routing_key = None;
 
-        let event = PendingEvent::without_header(routing_key, data, None, tx).expect("create pending event");
+        let event =
+            PendingEvent::without_header(None, routing_key, data, None, tx).expect("create pending event");
         assert!(event.is_empty());
 
         // test with illegal event size
@@ -193,7 +194,7 @@ mod tests {
         let data = vec![0; (PendingEvent::MAX_WRITE_SIZE + 1) as usize];
         let routing_key = None;
 
-        let event = PendingEvent::without_header(routing_key, data, None, tx);
+        let event = PendingEvent::without_header(None, routing_key, data, None, tx);
         assert!(event.is_none());
 
         let rt = Runtime::new().expect("get runtime");

--- a/src/segment/event.rs
+++ b/src/segment/event.rs
@@ -38,9 +38,14 @@ pub(crate) struct WriterInfo {
 }
 
 #[derive(Debug)]
+pub(crate) enum RoutingInfo {
+    RoutingKey(Option<String>),
+    Segment(ScopedSegment),
+}
+
+#[derive(Debug)]
 pub(crate) struct PendingEvent {
-    pub(crate) scoped_segment: Option<ScopedSegment>,
-    pub(crate) routing_key: Option<String>,
+    pub(crate) routing_info: RoutingInfo,
     pub(crate) data: Vec<u8>,
     pub(crate) conditional_offset: Option<i64>,
     pub(crate) oneshot_sender: oneshot::Sender<Result<(), Error>>,
@@ -49,8 +54,7 @@ pub(crate) struct PendingEvent {
 impl PendingEvent {
     pub(crate) const MAX_WRITE_SIZE: usize = 8 * 1024 * 1024 + 8;
     pub(crate) fn new(
-        scoped_segment: Option<ScopedSegment>,
-        routing_key: Option<String>,
+        routing_info: RoutingInfo,
         data: Vec<u8>,
         conditional_offset: Option<i64>,
         oneshot_sender: oneshot::Sender<Result<(), Error>>,
@@ -74,8 +78,7 @@ impl PendingEvent {
             None
         } else {
             Some(PendingEvent {
-                scoped_segment,
-                routing_key,
+                routing_info,
                 data,
                 conditional_offset,
                 oneshot_sender,
@@ -84,21 +87,14 @@ impl PendingEvent {
     }
 
     pub(crate) fn with_header(
-        scoped_segment: Option<ScopedSegment>,
-        routing_key: Option<String>,
+        routing_info: RoutingInfo,
         data: Vec<u8>,
         conditional_offset: Option<i64>,
         oneshot_sender: oneshot::Sender<Result<(), Error>>,
     ) -> Option<PendingEvent> {
         let cmd = EventCommand { data };
         match cmd.write_fields() {
-            Ok(data) => PendingEvent::new(
-                scoped_segment,
-                routing_key,
-                data,
-                conditional_offset,
-                oneshot_sender,
-            ),
+            Ok(data) => PendingEvent::new(routing_info, data, conditional_offset, oneshot_sender),
             Err(e) => {
                 warn!("failed to serialize event to event command, sending this error back to caller");
                 oneshot_sender
@@ -113,19 +109,12 @@ impl PendingEvent {
     }
 
     pub(crate) fn without_header(
-        scoped_segment: Option<ScopedSegment>,
-        routing_key: Option<String>,
+        routing_info: RoutingInfo,
         data: Vec<u8>,
         conditional_offset: Option<i64>,
         oneshot_sender: oneshot::Sender<Result<(), Error>>,
     ) -> Option<PendingEvent> {
-        PendingEvent::new(
-            scoped_segment,
-            routing_key,
-            data,
-            conditional_offset,
-            oneshot_sender,
-        )
+        PendingEvent::new(routing_info, data, conditional_offset, oneshot_sender)
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/src/segment/reactor.rs
+++ b/src/segment/reactor.rs
@@ -277,8 +277,14 @@ pub(crate) mod test {
         size: usize,
     ) -> oneshot::Receiver<Result<(), Error>> {
         let (oneshot_sender, oneshot_receiver) = tokio::sync::oneshot::channel();
-        let event = PendingEvent::new(Some("routing_key".into()), vec![1; size], None, oneshot_sender)
-            .expect("create pending event");
+        let event = PendingEvent::new(
+            None,
+            Some("routing_key".into()),
+            vec![1; size],
+            None,
+            oneshot_sender,
+        )
+        .expect("create pending event");
         sender.send((Incoming::AppendEvent(event), size)).await.unwrap();
         oneshot_receiver
     }

--- a/src/segment/reactor.rs
+++ b/src/segment/reactor.rs
@@ -276,7 +276,7 @@ pub(crate) mod test {
         size: usize,
     ) -> oneshot::Receiver<Result<(), Error>> {
         let (oneshot_sender, oneshot_receiver) = tokio::sync::oneshot::channel();
-        let routing_info = RoutingInfo::RoutingKey("routing_key".to_string());
+        let routing_info = RoutingInfo::RoutingKey(Some("routing_key".to_string()));
         let event = PendingEvent::new(routing_info, vec![1; size], None, oneshot_sender)
             .expect("create pending event");
         sender.send((Incoming::AppendEvent(event), size)).await.unwrap();

--- a/src/segment/selector.rs
+++ b/src/segment/selector.rs
@@ -22,12 +22,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tracing::{debug, warn};
 
-/// Maintains mapping from segments to segment writers.
+/// Maintain the mapping from segments to segment writers.
 pub(crate) struct SegmentSelector {
     /// The stream of this SegmentSelector.
     pub(crate) stream: ScopedStream,
 
-    /// Maps segment to SegmentWriter.
+    /// Map segment to SegmentWriter.
     pub(crate) writers: HashMap<ScopedSegment, SegmentWriter, RandomState>,
 
     /// The current segments in this stream.
@@ -60,7 +60,7 @@ impl SegmentSelector {
         }
     }
 
-    /// Initializes segment writers by setting up connections so that segment
+    /// Initialize segment writers by setting up connections so that segment
     /// writers are ready to use after initialization.
     pub(crate) async fn initialize(&mut self, stream_segments: Option<StreamSegments>) {
         if let Some(ss) = stream_segments {
@@ -76,12 +76,19 @@ impl SegmentSelector {
         self.create_missing_writers().await;
     }
 
-    /// Gets a segment writer by providing an optional routing key. The stream at least owns one
+    /// Get a segment writer by providing an optional routing key. The stream at least owns one
     /// segment so this method should always has writer to return.
     pub(crate) fn get_segment_writer(&mut self, routing_key: &Option<String>) -> &mut SegmentWriter {
         let segment = self
             .current_segments
             .get_segment_for_routing_key(routing_key, get_random_f64);
+        self.writers
+            .get_mut(segment)
+            .expect("must have corresponding writer")
+    }
+
+    /// Get a segment writer by providing the segment name.
+    pub(crate) fn get_segment_writer_by_key(&mut self, segment: &ScopedSegment) -> &mut SegmentWriter {
         self.writers
             .get_mut(segment)
             .expect("must have corresponding writer")

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -768,8 +768,14 @@ pub(crate) mod test {
         offset: Option<i64>,
     ) -> (PendingEvent, CapacityGuard, EventHandle) {
         let (oneshot_sender, oneshot_receiver) = tokio::sync::oneshot::channel();
-        let event = PendingEvent::new(Some("routing_key".into()), vec![1; size], offset, oneshot_sender)
-            .expect("create pending event");
+        let event = PendingEvent::new(
+            None,
+            Some("routing_key".into()),
+            vec![1; size],
+            offset,
+            oneshot_sender,
+        )
+        .expect("create pending event");
         sender.send((Incoming::AppendEvent(event), size)).await.unwrap();
         loop {
             let (event, guard) = receiver.recv().await.unwrap();

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -538,6 +538,7 @@ pub enum SegmentWriterError {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use crate::segment::event::RoutingInfo;
     use pravega_client_channel::{create_channel, ChannelReceiver};
     use pravega_client_config::connection_type::{ConnectionType, MockType};
     use pravega_client_config::ClientConfigBuilder;
@@ -769,8 +770,7 @@ pub(crate) mod test {
     ) -> (PendingEvent, CapacityGuard, EventHandle) {
         let (oneshot_sender, oneshot_receiver) = tokio::sync::oneshot::channel();
         let event = PendingEvent::new(
-            None,
-            Some("routing_key".into()),
+            RoutingInfo::RoutingKey(Some("routing_key".into())),
             vec![1; size],
             offset,
             oneshot_sender,


### PR DESCRIPTION
**Change log description**  
support multiple segments in byte stream

**Purpose of the change**  
Fix #262 

**What the code does**  
Add a `Option<ScopedSegment>` field in the `PendingEvent`. 
If the `Option` is not `None`, then `selector` will directly fetch the writer from the map using `segment` as a key.

**How to verify it**  
Tests should pass
