### PR TITLE
Issue 247: Accept scheme in controller URI

### DIFF
--- a/book/src/Python/PythonBindings.md
+++ b/book/src/Python/PythonBindings.md
@@ -14,7 +14,7 @@ A StreamManager can be created by using a Controller URI. The below example snip
 
  ```python
 import pravega_client
-manager=pravega_client.StreamManager("127.0.0.1:9090")
+manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # stream manager can be used to create scopes, streams, writers and readers against Pravega.
 manager.create_scope("scope")
 manager.create_stream("scope", "stream", 1)
@@ -24,7 +24,7 @@ A StreamWriter can be used create a Stream writer. The below snippet is shows a 
 
 ```python
 import pravega_client
-manager=pravega_client.StreamManager("127.0.0.1:9090")
+manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # create a writer against an already created Pravega scope and Stream.
 writer=manager.create_writer("scope", "stream")
 ```
@@ -32,7 +32,7 @@ A transactional Writer can be created using the StreamManager. The below example
 
 ```python
  import pravega_client
- manager=pravega_client.StreamManager("127.0.0.1:9090")
+ manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # create a transactional writer against an already created Pravega scope and Stream.
  writer=manager.create_transaction_writer("scope", "stream", "123")
  ```
@@ -41,7 +41,7 @@ A ReaderGroup can be created using the StreamManager. Individual readers can be 
 
 ```python
 import pravega_client
-manager=pravega_client.StreamManager("127.0.0.1:9090")
+manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # create a ReaderGroup rg1 against an already created Pravega scope and Stream.
 event.reader_group=manager.create_reader_group("rg1", "scope", "stream")
 ``` 
@@ -58,7 +58,7 @@ retries will not violate the exactly-once semantic, so it is better to rely on t
 
 ```python
 import pravega_client
-manager=pravega_client.StreamManager("127.0.0.1:9090")
+manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # assuming the Pravega scope and stream are already created.
 writer=manager.create_writer("scope", "stream")
 # write into Pravega stream without specifying the routing key.
@@ -83,7 +83,7 @@ Prior to committing a transaction, the events written to it cannot be read or ot
 
 ```python
 import pravega_client                                         
-manager = pravega_client.StreamManager("127.0.0.1:9090")        
+manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")        
 w1 = stream_manager.create_transaction_writer(scope,"testTxn", 1)
 # Begin a Transaction
 txn1 = w1.begin_txn()
@@ -116,7 +116,7 @@ A sample example snippet is shown below.
 
 ```python
 import pravega_client
-manager = pravega_client.StreamManager("127.0.0.1:9090")
+manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 # assuming the Pravega scope and stream are already created.
 reader_group = manager.create_reader_group("rg1", "scope", "stream")
 reader = reader_group.create_reader("reader_id");

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -47,9 +47,10 @@ const AUTH_PROPS_PREFIX_ENV: &str = "pravega_client_auth_";
 
 const TLS_CERT_PATH_ENV: &str = "pravega_client_tls_cert_path";
 const DEFAULT_TLS_CERT_PATH: &str = "./certs";
+const TLS_SCHEME: &str = "tls";
 
 #[derive(Builder, Debug, Getters, CopyGetters, Clone)]
-#[builder(setter(into))]
+#[builder(setter(into), build_fn(validate = "Self::validate"))]
 pub struct ClientConfig {
     #[get_copy = "pub"]
     #[builder(default = "u32::max_value()")]
@@ -68,7 +69,6 @@ pub struct ClientConfig {
     pub retry_policy: RetryWithBackoff,
 
     #[get]
-    #[builder(setter(into))]
     pub controller_uri: PravegaNodeUri,
 
     #[get_copy = "pub"]
@@ -79,12 +79,12 @@ pub struct ClientConfig {
     #[builder(default = "false")]
     pub mock: bool,
 
+    #[get_copy = "pub"]
+    #[builder(default = "self.default_is_tls_enabled()")]
+    pub is_tls_enabled: bool,
+
     #[builder(default = "self.extract_trustcerts()")]
     pub trustcerts: Vec<String>,
-
-    #[get_copy = "pub"]
-    #[builder(default = "false")]
-    pub is_tls_enabled: bool,
 
     #[builder(default = "self.extract_credentials()")]
     pub credentials: Credentials,
@@ -108,8 +108,10 @@ impl ClientConfigBuilder {
             if !enable {
                 return vec![];
             }
-        } else {
+        } else if !self.default_is_tls_enabled() {
             return vec![];
+        } else {
+            // fall through to parsing certs path
         }
         let ret_val = env::vars()
             .filter(|(k, _v)| k.starts_with(TLS_CERT_PATH_ENV))
@@ -157,6 +159,47 @@ impl ClientConfigBuilder {
 
     fn default_timeout(&self) -> Duration {
         Duration::from_secs(30)
+    }
+
+    fn default_is_tls_enabled(&self) -> bool {
+        if let Some(controller_uri) = &self.controller_uri {
+            return match controller_uri.scheme() {
+                Ok(scheme) => scheme == TLS_SCHEME,
+                Err(_) => false,
+            };
+        }
+        false
+    }
+    /// validate the builder before returning it
+    ///
+    /// if both is_tls_enabled and controller_uri have been set
+    /// verify that the uri scheme (if present) matches the is_tls_enabled
+    /// value.
+    fn validate(&self) -> Result<(), String> {
+        if self.is_tls_enabled.is_none() || self.controller_uri.is_none() {
+            // at least one option has not been specified, cannot have a conflict
+            return Ok(());
+        }
+        let is_tls_enabled = self.is_tls_enabled.unwrap();
+        let scheme_result = self.controller_uri.as_ref().unwrap().scheme();
+        if scheme_result.is_err() {
+            // unparsable URI, cannot have a conflict
+            // though maybe we should return the Err value
+            return Ok(());
+        }
+        let scheme = scheme_result.unwrap();
+        if scheme.is_empty() {
+            // no scheme specified, cannot have a conflict
+            return Ok(());
+        };
+
+        match (is_tls_enabled, scheme == TLS_SCHEME) {
+            (true, true) | (false, false) => Ok(()),
+            _ => Err(format!(
+                "is_tls_enabled option {} does not match uri scheme {}",
+                is_tls_enabled, scheme
+            )),
+        }
     }
 }
 
@@ -249,7 +292,7 @@ mod tests {
     #[test]
     fn test_extract_tls_cert_path() {
         // test default
-        fs::create_dir(DEFAULT_TLS_CERT_PATH).expect("create default cert path");
+        fs::create_dir_all(DEFAULT_TLS_CERT_PATH).expect("create default cert path");
         fs::File::create(format!("{}/foo.crt", DEFAULT_TLS_CERT_PATH)).expect("create crt");
         let config = ClientConfigBuilder::default()
             .controller_uri("127.0.0.2:9091".to_string())
@@ -257,10 +300,39 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(config.trustcerts.len(), 1);
-        fs::remove_dir_all(DEFAULT_TLS_CERT_PATH).expect("remove dir");
 
+        // test w/ tls uri prefix
+        let config = ClientConfigBuilder::default()
+            .controller_uri(format!("{}://127.0.0.2:9091", TLS_SCHEME))
+            .build()
+            .unwrap();
+        assert_eq!(config.trustcerts.len(), 1);
+
+        // test w/o tls uri prefix
+        let config = ClientConfigBuilder::default()
+            .controller_uri("tcp://127.0.0.2:9091".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(config.trustcerts.len(), 0);
+
+        // test conflicting tls setting vs scheme
+        let conflicted_config1 = ClientConfigBuilder::default()
+            .controller_uri(format!("{}://127.0.0.2:9091", TLS_SCHEME))
+            .is_tls_enabled(false)
+            .build();
+        assert!(conflicted_config1.is_err());
+
+        // test alternate conflicting tlst setting vs scheme
+        let conflicted_config2 = ClientConfigBuilder::default()
+            .controller_uri("tcp://127.0.0.2:9091".to_string())
+            .is_tls_enabled(true)
+            .build();
+
+        assert!(conflicted_config2.is_err());
+
+        fs::remove_dir_all(DEFAULT_TLS_CERT_PATH).expect("remove dir");
         // test with env var set
-        fs::create_dir("./bar").expect("create default cert path");
+        fs::create_dir_all("./bar").expect("create default cert path");
         fs::File::create(format!("./bar/foo.crt")).expect("create crt");
         env::set_var("pravega_client_tls_cert_path", "./bar");
         let config = ClientConfigBuilder::default()

--- a/connection_pool/src/connection_pool.rs
+++ b/connection_pool/src/connection_pool.rs
@@ -67,7 +67,7 @@ pub enum ConnectionPoolError {
 /// let mut rt = Runtime::new().unwrap();
 /// let manager = FooManager{};
 /// let pool = ConnectionPool::new(manager);
-/// let endpoint = PravegaNodeUri::from("127.0.0.1:12345");
+/// let endpoint = PravegaNodeUri::from("tcp://127.0.0.1:12345");
 /// let connection = rt.block_on(pool.get_connection(endpoint));
 /// ```
 #[async_trait]

--- a/controller-client/src/cli.rs
+++ b/controller-client/src/cli.rs
@@ -62,8 +62,8 @@ enum Command {
     version = "0.1"
 )]
 struct Opt {
-    /// Used to configure controller grpc, default uri http://127.0.0.1:9090
-    #[structopt(short = "uri", long, default_value = "127.0.0.1:9090")]
+    /// Used to configure controller grpc, default uri tcp://127.0.0.1:9090
+    #[structopt(short = "uri", long, default_value = "tcp://127.0.0.1:9090")]
     controller_uri: String,
 
     #[structopt(subcommand)] // Note that we mark a field as a subcommand

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -296,9 +296,19 @@ async fn get_channel(config: &ClientConfig) -> Channel {
 
     // Placeholder to add authentication headers.
     let s = if config.is_tls_enabled {
-        format!("{}{}", HTTPS_PREFIX, &config.controller_uri.to_string())
+        format!(
+            "{}{}:{}",
+            HTTPS_PREFIX,
+            &config.controller_uri.domain_name(),
+            config.controller_uri.port()
+        )
     } else {
-        format!("{}{}", HTTP_PREFIX, &config.controller_uri.to_string())
+        format!(
+            "{}{}:{}",
+            HTTP_PREFIX,
+            &config.controller_uri.domain_name(),
+            config.controller_uri.port()
+        )
     };
     let uri_result = Uri::from_str(s.as_str())
         .map_err(|e1: InvalidUri| ControllerError::InvalidConfiguration {

--- a/integration_test/src/event_writer_tests.rs
+++ b/integration_test/src/event_writer_tests.rs
@@ -110,7 +110,7 @@ async fn test_simple_write(writer: &mut EventWriter) {
 
     for rx in receivers {
         let reply: Result<(), Error> = rx.await.expect("wait for result from oneshot");
-        assert_eq!(reply.is_ok(), true);
+        assert!(reply.is_ok());
     }
     info!("test simple write passed");
 }
@@ -150,7 +150,7 @@ async fn test_segment_scaling_up(writer: &mut EventWriter, factory: &ClientFacto
 
     for rx in receivers {
         let reply: Result<(), Error> = rx.await.expect("wait for result from oneshot");
-        assert_eq!(reply.is_ok(), true);
+        assert!(reply.is_ok());
     }
 
     info!("test event stream writer with segment scaled up passed");
@@ -189,7 +189,7 @@ async fn test_segment_scaling_down(writer: &mut EventWriter, factory: &ClientFac
 
     for rx in receivers {
         let reply: Result<(), Error> = rx.await.expect("wait for result from oneshot");
-        assert_eq!(reply.is_ok(), true);
+        assert!(reply.is_ok());
     }
     info!("test event stream writer with segment sealed passed");
 }
@@ -198,7 +198,7 @@ async fn test_write_correctness(writer: &mut EventWriter, factory: &ClientFactor
     info!("test read and write");
     let rx = writer.write_event(String::from("event0").into_bytes()).await;
     let reply: Result<(), Error> = rx.await.expect("wait for result from oneshot");
-    assert_eq!(reply.is_ok(), true);
+    assert!(reply.is_ok());
     let scope_name = Scope::from("testScopeWriter2".to_owned());
     let stream_name = Stream::from("testStreamWriter2".to_owned());
     let segment_name = ScopedSegment {
@@ -253,8 +253,8 @@ async fn test_write_correctness_while_scaling(writer: &mut EventWriter, factory:
             assert_eq!(2, current_segments_result.unwrap().key_segment_map.len());
         }
 
+        let data = format!("event{}", i);
         if i % 2 == 0 {
-            let data = format!("event{}", i);
             // Routing key "even" and "odd" works is because their hashed value are in
             // 0~0.5 and 0.5~1.0 respectively. If the routing key hashing algorithm changed, this
             // test might fail.
@@ -263,7 +263,6 @@ async fn test_write_correctness_while_scaling(writer: &mut EventWriter, factory:
                 .await;
             receivers.push(rx);
         } else {
-            let data = format!("event{}", i);
             let rx = writer
                 .write_event_by_routing_key(String::from("odd"), data.into_bytes())
                 .await;
@@ -274,7 +273,7 @@ async fn test_write_correctness_while_scaling(writer: &mut EventWriter, factory:
     // the data should write successfully.
     for rx in receivers {
         let reply: Result<(), Error> = rx.await.expect("wait for result from oneshot");
-        assert_eq!(reply.is_ok(), true);
+        assert!(reply.is_ok());
     }
 
     let segment_name = ScopedSegment {
@@ -351,14 +350,13 @@ async fn test_write_correctness_with_routing_key(writer: &mut EventWriter, facto
     let stream_name = Stream::from("testStreamWriter3".to_owned());
     let mut receivers = vec![];
     while i < count {
+        let data = format!("event{}", i);
         if i % 2 == 0 {
-            let data = format!("event{}", i);
             let rx = writer
                 .write_event_by_routing_key(String::from("even"), data.into_bytes())
                 .await;
             receivers.push(rx);
         } else {
-            let data = format!("event{}", i);
             let rx = writer
                 .write_event_by_routing_key(String::from("odd"), data.into_bytes())
                 .await;

--- a/integration_test/src/table_tests.rs
+++ b/integration_test/src/table_tests.rs
@@ -298,7 +298,7 @@ async fn test_iterators(client_factory: &ClientFactory) {
             Ok(t) => {
                 let k: String = t.0;
                 info!("key {:?} version {:?}", k, t.1);
-                assert_eq!(false, k.is_empty());
+                assert!(!k.is_empty());
                 key_count += 1;
             }
             _ => panic!("Failed fetch keys."),
@@ -317,8 +317,8 @@ async fn test_iterators(client_factory: &ClientFactory) {
                 let v: String = t.1;
 
                 info!("key {:?} value {:?} version {:?}", k, v, t.2);
-                assert_eq!(false, k.is_empty());
-                assert_eq!(false, v.is_empty());
+                assert!(!k.is_empty());
+                assert!(!v.is_empty());
                 entry_count += 1;
             }
             _ => panic!("Failed fetch entries."),

--- a/python_binding/README.md
+++ b/python_binding/README.md
@@ -26,7 +26,7 @@ The users can also choose to generate the bindings using the commands specified 
 ```python
 import pravega_client
 # assuming Pravega controller is listening at 127.0.0.1:9090
-stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
 scope_result = stream_manager.create_scope("scope_foo")
 self.assertEqual(True, scope_result, "Scope creation status")
@@ -41,7 +41,7 @@ writer.write_event("hello world")
 ```python
 import pravega_client
 # assuming Pravega controller is listening at 127.0.0.1:9090
-stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
 reader_group = stream_manager.create_reader_group("my_reader_group", "scope_foo", "stream_bar")
 

--- a/python_binding/src/stream_manager.rs
+++ b/python_binding/src/stream_manager.rs
@@ -27,7 +27,7 @@ cfg_if! {
 /// Create a StreamManager by providing a controller uri.
 /// ```
 /// import pravega_client;
-/// manager=pravega_client.StreamManager("127.0.0.1:9090")
+/// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 /// // this manager can be used to create scopes, streams, writers and readers against Pravega.
 /// manager.create_scope("scope")
 ///
@@ -48,7 +48,7 @@ pub(crate) struct StreamManager {
 /// Create a StreamManager by providing a controller uri.
 /// ```
 /// import pravega_client;
-/// manager=pravega_client.StreamManager("127.0.0.1:9090")
+/// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 /// // this manager can be used to create scopes, streams, writers and readers against Pravega.
 /// manager.create_scope("scope")
 ///
@@ -210,7 +210,7 @@ impl StreamManager {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // Create a writer against an already created Pravega scope and Stream.
     /// writer=manager.create_writer("scope", "stream")
     /// ```
@@ -234,7 +234,7 @@ impl StreamManager {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // Create a transactional writer against an already created Pravega scope and Stream.
     /// writer=manager.create_transaction_writer("scope", "stream", "123")
     /// ```
@@ -264,7 +264,7 @@ impl StreamManager {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // Create a ReaderGroup against an already created Pravega scope and Stream.
     /// event.reader_group=manager.create_reader_group("rg1", "scope", "stream")
     /// ```

--- a/python_binding/src/stream_reader.rs
+++ b/python_binding/src/stream_reader.rs
@@ -49,7 +49,7 @@ impl StreamReader {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // lets assume the Pravega scope and stream are already created.
     /// reader=manager.create_reader("scope", "stream");
     /// slice=await reader.get_segment_slice_async()

--- a/python_binding/src/stream_reader_group.rs
+++ b/python_binding/src/stream_reader_group.rs
@@ -48,7 +48,7 @@ impl StreamReaderGroup {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // lets assume the Pravega scope and stream are already created.
     /// event.reader_group=manager.create_reader_group("rg1", "scope", "stream")
     /// reader=event.reader_group.create_reader("reader_id");

--- a/python_binding/src/stream_writer.rs
+++ b/python_binding/src/stream_writer.rs
@@ -55,7 +55,7 @@ impl StreamWriter {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // lets assume the Pravega scope and stream are already created.
     /// writer=manager.create_writer("scope", "stream")
     /// // write into Pravega stream without specifying the routing key.
@@ -80,7 +80,7 @@ impl StreamWriter {
     ///
     /// ```
     /// import pravega_client;
-    /// manager=pravega_client.StreamManager("127.0.0.1:9090")
+    /// manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
     /// // lets assume the Pravega scope and stream are already created.
     /// writer=manager.create_writer("scope", "stream")
     ///

--- a/python_binding/tests/pravega_client_test.py
+++ b/python_binding/tests/pravega_client_test.py
@@ -20,7 +20,7 @@ class PravegaTest(unittest.TestCase):
         scope = ''.join(secrets.choice(string.ascii_lowercase + string.digits)
                       for i in range(10))
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager=pravega_client.StreamManager("127.0.0.1:9090", False, False)
+        stream_manager=pravega_client.StreamManager("tcp://127.0.0.1:9090", False, False)
 
         print("Creating a scope")
         scope_result=stream_manager.create_scope(scope)
@@ -41,7 +41,7 @@ class PravegaTest(unittest.TestCase):
         scope = ''.join(secrets.choice(string.ascii_lowercase + string.digits)
                         for i in range(10))
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager=pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result=stream_manager.create_scope(scope)
@@ -76,7 +76,7 @@ class PravegaTest(unittest.TestCase):
                         for i in range(10))
 
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager=pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager=pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result=stream_manager.create_scope(scope)

--- a/python_binding/tests/pravega_reader_test.py
+++ b/python_binding/tests/pravega_reader_test.py
@@ -29,7 +29,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
         scope = "testRead"
         stream = "testStream" + suffix
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result = stream_manager.create_scope(scope)
@@ -64,7 +64,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
         scope = "testRead"
         stream = "testMulti" + suffix
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result = stream_manager.create_scope(scope)
@@ -112,7 +112,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
         scope = "testRead"
         stream = "testPartial" + suffix
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result = stream_manager.create_scope(scope)
@@ -165,7 +165,7 @@ class PravegaReaderTest(aiounittest.AsyncTestCase):
         scope = "testRead"
         stream = "testLargeEvent" + suffix
         print("Creating a Stream Manager, ensure Pravega is running")
-        stream_manager = pravega_client.StreamManager("127.0.0.1:9090")
+        stream_manager = pravega_client.StreamManager("tcp://127.0.0.1:9090")
 
         print("Creating a scope")
         scope_result = stream_manager.create_scope(scope)

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -25,3 +25,5 @@ murmurhash3 = "0.0.5"
 encoding_rs = "0.8"
 derive_more = "0.99.9"
 tokio = { version = "1.1", features = ["full"] }
+regex = "1.3"
+lazy_static = "1.4"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -145,7 +145,7 @@ impl PravegaNodeUri {
         // where the first endpoint has the scheme to be applied to all endpoints.
         // To be semi-compatible with the Java code this method accepts a string containing comma separated
         // endpoints, but it uses only the first endpoint in the string
-        let first_endpoint = match uri.split(",").nth(0) {
+        let first_endpoint = match uri.split(',').next() {
             Some(endpoint) => endpoint,
             _ => {
                 return Err(PravegaNodeUriParseError::ParseError {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -62,7 +62,7 @@ pub enum PravegaNodeUriParseError {
 #[derive(Debug, PartialEq, Default)]
 struct PravegaNodeUriParts {
     scheme: Option<String>,
-    authority: Option<String>,
+    domain_name: Option<String>,
     port: Option<u16>,
 }
 
@@ -94,7 +94,7 @@ impl PravegaNodeUri {
         match PravegaNodeUri::uri_parts_from_string(self.to_string()) {
             Ok(uri_parts) => {
                 let mut addrs_vec: Vec<_> =
-                    format!("{}:{}", uri_parts.authority.unwrap(), uri_parts.port.unwrap())
+                    format!("{}:{}", uri_parts.domain_name.unwrap(), uri_parts.port.unwrap())
                         .to_socket_addrs()
                         .expect("Unable to resolve domain")
                         .collect();
@@ -106,7 +106,7 @@ impl PravegaNodeUri {
 
     pub fn domain_name(&self) -> String {
         match PravegaNodeUri::uri_parts_from_string(self.to_string()) {
-            Ok(uri_parts) => uri_parts.authority.expect("uri missing authority"),
+            Ok(uri_parts) => uri_parts.domain_name.expect("uri missing authority"),
             Err(e) => panic!("{}", e),
         }
     }
@@ -133,7 +133,7 @@ impl PravegaNodeUri {
     ///
     pub fn is_well_formed(uri: String) -> bool {
         match PravegaNodeUri::uri_parts_from_string(uri) {
-            Ok(uri_parts) => uri_parts.port.is_some() && uri_parts.authority.is_some(),
+            Ok(uri_parts) => uri_parts.port.is_some() && uri_parts.domain_name.is_some(),
             Err(_) => false,
         }
     }
@@ -160,7 +160,7 @@ impl PravegaNodeUri {
                 })
             }
             2 => {
-                uri_parts.authority = Some(authority_port_parts[0].to_string());
+                uri_parts.domain_name = Some(authority_port_parts[0].to_string());
                 uri_parts.port = Some(
                     authority_port_parts[1]
                         .parse::<u16>()
@@ -840,7 +840,7 @@ mod test {
             PravegaNodeUri::uri_parts_from_string("127.0.0.1:9090".to_string()).unwrap(),
             PravegaNodeUriParts {
                 scheme: None,
-                authority: Some("127.0.0.1".to_string()),
+                domain_name: Some("127.0.0.1".to_string()),
                 port: Some(9090)
             }
         );
@@ -850,7 +850,7 @@ mod test {
             PravegaNodeUri::uri_parts_from_string(uri_with_scheme.to_string()).unwrap(),
             PravegaNodeUriParts {
                 scheme: Some("tls".to_string()),
-                authority: Some("127.0.0.1".to_string()),
+                domain_name: Some("127.0.0.1".to_string()),
                 port: Some(9090),
             }
         );
@@ -864,7 +864,7 @@ mod test {
             PravegaNodeUri::uri_parts_from_string(uri_with_scheme.to_string()).unwrap(),
             PravegaNodeUriParts {
                 scheme: Some("ssl".to_string()),
-                authority: Some("127.0.0.1".to_string()),
+                domain_name: Some("127.0.0.1".to_string()),
                 port: Some(9090),
             }
         );

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -343,10 +343,10 @@ impl From<&str> for ScopedSegment {
             ScopedSegment::from(original_segment_name)
         } else {
             let mut tokens = NameUtils::extract_segment_tokens(qualified_name.to_owned());
-            if tokens.len() == 2 {
+            let segment_id = tokens.pop().expect("get segment id from tokens");
+            let stream_name = tokens.pop().expect("get stream name from tokens");
+            if tokens.is_empty() {
                 // scope not present
-                let segment_id = tokens.pop().expect("get segment id from tokens");
-                let stream_name = tokens.pop().expect("get stream name from tokens");
                 ScopedSegment {
                     scope: Scope {
                         name: String::from(""),
@@ -358,8 +358,6 @@ impl From<&str> for ScopedSegment {
                     },
                 }
             } else {
-                let segment_id = tokens.pop().expect("get segment id from tokens");
-                let stream_name = tokens.pop().expect("get stream name from tokens");
                 let scope = tokens.pop().expect("get scope from tokens");
                 ScopedSegment {
                     scope: Scope { name: scope },

--- a/src/client_factory.rs
+++ b/src/client_factory.rs
@@ -226,13 +226,11 @@ impl ClientFactoryInternal {
         stream: ScopedStream,
     ) -> DelegationTokenProvider {
         let token_provider = DelegationTokenProvider::new(stream);
-        if self.config.is_auth_enabled {
-            token_provider
-        } else {
+        if !self.config.is_auth_enabled {
             let empty_token = DelegationToken::new("".to_string(), None);
             token_provider.populate(empty_token).await;
-            token_provider
         }
+        token_provider
     }
 
     pub(crate) fn get_connection_pool(&self) -> &ConnectionPool<SegmentConnectionManager> {

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -486,7 +486,7 @@ impl EventReader {
                         } else {
                             //None is sent if the the segment is released from the reader.
                             debug!("ignore the received data since None was returned");
-                            return None;
+                            None
                         }
                     }
                     Err((e, offset)) => {

--- a/src/event/transactional_writer.rs
+++ b/src/event/transactional_writer.rs
@@ -58,7 +58,7 @@ use tracing_futures::Instrument;
 ///     // omit the step to create scope and stream in Pravega
 ///
 ///     let config = ClientConfigBuilder::default()
-///         .controller_uri(PravegaNodeUri::from("127.0.0.2:9091".to_string()))
+///         .controller_uri(PravegaNodeUri::from("tcp://127.0.0.2:9091".to_string()))
 ///         .build()
 ///         .expect("creating config");
 ///     let client_factory = ClientFactory::new(config);

--- a/src/segment/metadata.rs
+++ b/src/segment/metadata.rs
@@ -98,10 +98,8 @@ impl SegmentMetadataClient {
                 Err(e) => {
                     if e.is_token_expired() {
                         self.delegation_token_provider.signal_token_expiry();
-                        RetryResult::Retry(e.to_string())
-                    } else {
-                        RetryResult::Retry(e.to_string())
                     }
+                    RetryResult::Retry(e.to_string())
                 }
             }
         })
@@ -159,10 +157,8 @@ impl SegmentMetadataClient {
                 Err(e) => {
                     if e.is_token_expired() {
                         self.delegation_token_provider.signal_token_expiry();
-                        RetryResult::Retry(e.to_string())
-                    } else {
-                        RetryResult::Retry(e.to_string())
                     }
+                    RetryResult::Retry(e.to_string())
                 }
             }
         })
@@ -208,10 +204,8 @@ impl SegmentMetadataClient {
                 Err(e) => {
                     if e.is_token_expired() {
                         self.delegation_token_provider.signal_token_expiry();
-                        RetryResult::Retry(e.to_string())
-                    } else {
-                        RetryResult::Retry(e.to_string())
                     }
+                    RetryResult::Retry(e.to_string())
                 }
             }
         })

--- a/src/sync/synchronizer.rs
+++ b/src/sync/synchronizer.rs
@@ -349,20 +349,17 @@ impl InternalKey {
     fn split(&self) -> (String, Option<String>) {
         let outer_name_length: usize = self.key[..PREFIX_LENGTH].parse().expect("parse prefix length");
         assert!(self.key.len() >= PREFIX_LENGTH + outer_name_length);
+        let outer = self.key[PREFIX_LENGTH..PREFIX_LENGTH + outer_name_length]
+            .parse::<String>()
+            .expect("parse outer key");
 
         if self.key.len() > PREFIX_LENGTH + outer_name_length {
-            let outer = self.key[PREFIX_LENGTH..PREFIX_LENGTH + outer_name_length]
-                .parse::<String>()
-                .expect("parse outer key");
             // there is a slash separating outer_key and_inner key
             let inner = self.key[PREFIX_LENGTH + outer_name_length + 1..]
                 .parse::<String>()
                 .expect("parse inner key");
             (outer, Some(inner))
         } else {
-            let outer = self.key[PREFIX_LENGTH..PREFIX_LENGTH + outer_name_length]
-                .parse::<String>()
-                .expect("parse outer key");
             (outer, None)
         }
     }


### PR DESCRIPTION
**Change log description**  
* allow scheme to be included in PravegaNodeUri
* changes ClientConfigBuilder to automatically set `is_tls_enabled = true` when uri scheme is 'tls'
* allows tls scheme to be used with StreamManager Python client when tls_enabled default value (false) is used

**Purpose of the change**  

Fixes #247 

**What the code does**  
changes to shared/lib
* accepts schemes in PravegaNodeUri
* added PravegaNodeUriParseError
* added PravegaNodeUri::is_well_formed static method
* added PravegaNodeUri::uri_parts_from_string static method
* changed existing methods to use uri_parts_from_string

changes to config/lib
* added default builder for `ClientConfigBuilder::is_tls_enabled`
* altered `ClientConfigBuilder::extract_trustcerts` to also call `default_is_tls_enabled` (builder order of operations calls extract_trustcerts before default_is_tls_enabled)
* added `ClientConfigBuilder::validate` to check for conflicts between uri scheme and `.is_tls_enabled()`
* removed duplicate `builder(setter(into))`  from controller_uri because its already set at the struct level

changes to python_binding/stream_manager
* changed `StreamManager` constructor, if `tls_enabled = false` then rely on the scheme from `controller_uri` to set `is_tls_enabled`
* updated sample usage


**How to verify it**  

* rust tests have been added 
* was not able to test python changes due to issues with maturin

**Comments**

The only uri scheme this code specifically tests for is `tls`. It should probably only allow `tcp, tls` schemes (but see my outstanding question on #247)

Some existing PravegaNodeUri methods panic if the uri is malformed. I added `is_well_formed` static method so that library consumers could test a uri before building a clientconfig.  This approach seems a bit dodgy. Perhaps changing PravegaNodeUri to a struct not derived from String could improve this, but I think that would require more changes to the library.

If we want true backwards compatibility with the python client, we may wish to change StreamManager `tls_enabled` arg to `PyAny` type, then set the default python arg to either `None` or a sentinel object that can make it clear whether or not the python caller provided a value for `tls_enabled`

This is my first rust code. Some of the changes don't look quite right. I considered using Regex but its currently only used in the auth crate, so didn't seem worth pulling into this one.


