### PR TITLE
Issue 257: Enable Reader offline

### DIFF
--- a/integration_test/src/synchronizer_tests.rs
+++ b/integration_test/src/synchronizer_tests.rs
@@ -55,7 +55,6 @@ async fn test_insert(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
-            Ok(None)
         })
         .await;
 
@@ -68,7 +67,6 @@ async fn test_insert(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -108,7 +106,6 @@ async fn test_remove(client_factory: &ClientFactory) {
                     Box::new(2),
                 );
             }
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -118,7 +115,6 @@ async fn test_remove(client_factory: &ClientFactory) {
             if table.get("outer_key", "inner_key").is_some() {
                 table.insert_tombstone("outer_key".to_owned(), "inner_key".to_owned())?;
             }
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -166,7 +162,6 @@ async fn test_insert_with_two_table_synchronizers(client_factory: &ClientFactory
                     );
                 }
             }
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -195,7 +190,6 @@ async fn test_insert_with_two_table_synchronizers(client_factory: &ClientFactory
                     );
                 }
             }
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -230,7 +224,6 @@ async fn test_remove_with_two_table_synchronizers(client_factory: &ClientFactory
             if data == 3 {
                 table.insert_tombstone("outer_key".to_owned(), "inner_key".to_owned())?;
             }
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -248,7 +241,6 @@ async fn test_remove_with_two_table_synchronizers(client_factory: &ClientFactory
                     Box::new(4),
                 );
             }
-            Ok(None)
         })
         .await;
 
@@ -294,7 +286,6 @@ async fn test_insert_and_get_with_customize_struct(client_factory: &ClientFactor
                 "Test2".to_owned(),
                 Box::new(Test2 { age: 10 }),
             );
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -334,7 +325,6 @@ async fn test_fetching_updates_delta(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
-            Ok(None)
         })
         .await;
     assert!(result.is_ok());
@@ -348,7 +338,6 @@ async fn test_fetching_updates_delta(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(2),
             );
-            Ok(None)
         })
         .await;
     let updates2 = synchronizer.fetch_updates().await.expect("fetch updates");

--- a/integration_test/src/synchronizer_tests.rs
+++ b/integration_test/src/synchronizer_tests.rs
@@ -55,6 +55,7 @@ async fn test_insert(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
+            Ok(())
         })
         .await;
 
@@ -67,6 +68,7 @@ async fn test_insert(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -106,6 +108,7 @@ async fn test_remove(client_factory: &ClientFactory) {
                     Box::new(2),
                 );
             }
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -115,6 +118,7 @@ async fn test_remove(client_factory: &ClientFactory) {
             if table.get("outer_key", "inner_key").is_some() {
                 table.insert_tombstone("outer_key".to_owned(), "inner_key".to_owned())?;
             }
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -162,6 +166,7 @@ async fn test_insert_with_two_table_synchronizers(client_factory: &ClientFactory
                     );
                 }
             }
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -190,6 +195,7 @@ async fn test_insert_with_two_table_synchronizers(client_factory: &ClientFactory
                     );
                 }
             }
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -224,6 +230,7 @@ async fn test_remove_with_two_table_synchronizers(client_factory: &ClientFactory
             if data == 3 {
                 table.insert_tombstone("outer_key".to_owned(), "inner_key".to_owned())?;
             }
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -241,6 +248,7 @@ async fn test_remove_with_two_table_synchronizers(client_factory: &ClientFactory
                     Box::new(4),
                 );
             }
+            Ok(())
         })
         .await;
 
@@ -286,6 +294,7 @@ async fn test_insert_and_get_with_customize_struct(client_factory: &ClientFactor
                 "Test2".to_owned(),
                 Box::new(Test2 { age: 10 }),
             );
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -325,6 +334,7 @@ async fn test_fetching_updates_delta(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(1),
             );
+            Ok(())
         })
         .await;
     assert!(result.is_ok());
@@ -338,6 +348,7 @@ async fn test_fetching_updates_delta(client_factory: &ClientFactory) {
                 "i32".to_owned(),
                 Box::new(2),
             );
+            Ok(())
         })
         .await;
     let updates2 = synchronizer.fetch_updates().await.expect("fetch updates");

--- a/python_binding/src/stream_reader.rs
+++ b/python_binding/src/stream_reader.rs
@@ -28,7 +28,7 @@ cfg_if! {
 /// This represents a Stream reader for a given Stream.
 /// Note: A python object of StreamReader cannot be created directly without using the StreamManager.
 ///
-#[cfg(feature = "python_binding")]
+//#[cfg(feature = "python_binding")]
 #[pyclass]
 #[derive(new)]
 pub(crate) struct StreamReader {
@@ -158,7 +158,7 @@ impl StreamReader {
 /// This represents a Stream reader for a given Stream.
 /// Note: A python object of StreamReader cannot be created directly without using the StreamManager.
 ///
-#[cfg(feature = "python_binding")]
+//#[cfg(feature = "python_binding")]
 #[pyclass]
 #[derive(new)]
 pub(crate) struct EventData {

--- a/python_binding/src/stream_reader.rs
+++ b/python_binding/src/stream_reader.rs
@@ -8,6 +8,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+use std::io::Error;
 cfg_if! {
     if #[cfg(feature = "python_binding")] {
         use pravega_client::event::reader::EventReader;
@@ -92,7 +93,7 @@ impl StreamReader {
     ///
     #[text_signature = "($self)"]
     pub fn reader_offline(&self) -> PyResult<()> {
-        self.factory.runtime().block_on(self.reader_offline_async());
+        self.factory.runtime().block_on(self.reader_offline_async())?;
         Ok(())
     }
 
@@ -103,7 +104,7 @@ impl StreamReader {
     pub fn release_segment(&self, slice: &mut Slice) -> PyResult<()> {
         info!("Release segment slice back");
         if let Some(s) = slice.get_set_to_none() {
-            self.factory.runtime().block_on(self.release_segment_async(s));
+            self.factory.runtime().block_on(self.release_segment_async(s))?;
         }
         Ok(())
     }
@@ -144,13 +145,13 @@ impl StreamReader {
     }
 
     // Helper method for to set reader_offline.
-    async fn reader_offline_async(&self) {
-        self.reader.lock().await.reader_offline().await;
+    async fn reader_offline_async(&self) -> Result<(), Error>{
+        self.reader.lock().await.reader_offline().await
     }
 
     // Helper method for to release segment
-    async fn release_segment_async(&self, slice: SegmentSlice) {
-        self.reader.lock().await.release_segment(slice).await;
+    async fn release_segment_async(&self, slice: SegmentSlice) -> Result<(), Error>{
+        self.reader.lock().await.release_segment(slice).await
     }
 }
 

--- a/src/event/reader_group.rs
+++ b/src/event/reader_group.rs
@@ -10,7 +10,7 @@
 
 use crate::client_factory::ClientFactory;
 use crate::event::reader::EventReader;
-use crate::event::reader_group_state::Offset;
+use crate::event::reader_group_state::{Offset, ReaderGroupStateError};
 
 use pravega_client_shared::{Reader, Scope, ScopedSegment, ScopedStream};
 
@@ -68,7 +68,7 @@ cfg_if::cfg_if! {
 pub struct ReaderGroup {
     pub name: String,
     config: ReaderGroupConfig,
-    pub state: Arc<Mutex<ReaderGroupState>>,
+    state: Arc<Mutex<ReaderGroupState>>,
     client_factory: ClientFactory,
 }
 
@@ -151,19 +151,40 @@ impl ReaderGroup {
     /// let reader = rg.create_reader("reader".to_string()).await;
     /// ```
     pub async fn create_reader(&self, reader_id: String) -> EventReader {
-        let r: Reader = Reader::from(reader_id.clone());
+        let r: Reader = reader_id.into();
         self.state
             .lock()
             .await
             .add_reader(&r)
             .await
             .expect("Error while creating the reader");
-        EventReader::init_reader(reader_id, self.state.clone(), self.client_factory.clone()).await
+        EventReader::init_reader(r.name, self.state.clone(), self.client_factory.clone()).await
+    }
+
+    /// Returns the readers which are currently online
+    pub async fn list_readers(&self) -> Vec<Reader> {
+        self.state.lock().await.get_online_readers().await
+    }
+
+    /// Removes a reader from the reader group. (Because it is offline)
+    /// Normally, readers shutdown gracefully by calling `reader_offline` on the reader itself.
+    /// However, if the process dies, this provides an alternative way to shutdown the reader.
+    ///
+    /// `last_position` is a map containing the last offsets processed by the reader. There is no requirement for
+    /// the map to be complete, or even non-empty. If a segment is missing, the last known value will be
+    /// assumed.
+    ///
+    /// If the reader is already offline, this method will have no effect.
+    pub async fn reader_offline(&self, reader: &Reader, last_position: HashMap<ScopedSegment, Offset>) -> Result<(), ReaderGroupStateError> {
+        self.state
+            .lock()
+            .await
+            .remove_reader(&reader, last_position).await
     }
 }
 
-// Specifies the ReaderGroupConfig.
-// ReaderGroupConfig::default() ensures the group refresh interval is set to 3 seconds.
+/// Specifies the ReaderGroupConfig.
+/// ReaderGroupConfig::default() ensures the group refresh interval is set to 3 seconds.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ReaderGroupConfig {
     pub(crate) config: ReaderGroupConfigVersioned,
@@ -248,7 +269,7 @@ impl Default for ReaderGroupConfigBuilder {
     }
 }
 
-// ReaderGroupConfigVersioned enum contains all versions of Position struct
+/// ReaderGroupConfigVersioned enum contains all versions of Position struct
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub(crate) enum ReaderGroupConfigVersioned {
     V1(ReaderGroupConfigV1),

--- a/src/event/reader_group.rs
+++ b/src/event/reader_group.rs
@@ -161,7 +161,7 @@ impl ReaderGroup {
         EventReader::init_reader(r.name, self.state.clone(), self.client_factory.clone()).await
     }
 
-    /// Returns the readers which are currently online
+    /// Returns the readers which are currently online.
     pub async fn list_readers(&self) -> Vec<Reader> {
         self.state.lock().await.get_online_readers().await
     }
@@ -175,11 +175,16 @@ impl ReaderGroup {
     /// assumed.
     ///
     /// If the reader is already offline, this method will have no effect.
-    pub async fn reader_offline(&self, reader: &Reader, last_position: HashMap<ScopedSegment, Offset>) -> Result<(), ReaderGroupStateError> {
+    pub async fn reader_offline(
+        &self,
+        reader: &Reader,
+        last_position: HashMap<ScopedSegment, Offset>,
+    ) -> Result<(), ReaderGroupStateError> {
         self.state
             .lock()
             .await
-            .remove_reader(&reader, last_position).await
+            .remove_reader(reader, last_position)
+            .await
     }
 }
 

--- a/src/event/reader_group_state.rs
+++ b/src/event/reader_group_state.rs
@@ -97,7 +97,7 @@ impl ReaderGroupState {
             } else {
                 info!("ReaderGroup {:?} already initialized", reader_group_name);
             }
-            Ok(None)
+            Ok(())
         })
         .await
         .expect("should initialize table synchronizer");
@@ -119,7 +119,7 @@ impl ReaderGroupState {
 
     // Internal logic of add_reader method. Separate the actual logic with table synchronizer
     // to facilitate the unit test.
-    fn add_reader_internal(table: &mut Update, reader: &Reader) -> Result<Option<String>, SynchronizerError> {
+    fn add_reader_internal(table: &mut Update, reader: &Reader) -> Result<(), SynchronizerError> {
         if table.contains_key(ASSIGNED, &reader.to_string()) {
             return Err(SynchronizerError::SyncUpdateError {
                 error_msg: format!("Failed to add online reader {:?}: reader already online", reader),
@@ -141,7 +141,7 @@ impl ReaderGroupState {
             "u64".to_owned(),
             Box::new(u64::MAX),
         );
-        Ok(None)
+        Ok(())
     }
 
     /// Returns the active readers in a vector.
@@ -251,7 +251,7 @@ impl ReaderGroupState {
         table: &mut Update,
         reader: &Reader,
         owned_segments: &HashMap<ScopedSegment, Offset>,
-    ) -> Result<Option<String>, SynchronizerError> {
+    ) -> Result<(), SynchronizerError> {
         let assigned_segments = ReaderGroupState::get_reader_owned_segments_from_table(table, reader)?;
 
         for (segment, pos) in assigned_segments {
@@ -267,7 +267,7 @@ impl ReaderGroupState {
         }
         table.insert_tombstone(ASSIGNED.to_owned(), reader.to_string())?;
         table.insert_tombstone(DISTANCE.to_owned(), reader.to_string())?;
-        Ok(None)
+        Ok(())
     }
 
     /// Compute the number of segments to acquire.
@@ -425,7 +425,7 @@ impl ReaderGroupState {
         reader: &Reader,
         segment: &ScopedSegment,
         offset: &Offset,
-    ) -> Result<Option<String>, SynchronizerError> {
+    ) -> Result<(), SynchronizerError> {
         let mut assigned_segments = ReaderGroupState::get_reader_owned_segments_from_table(table, reader)?;
         let unassigned_segments = ReaderGroupState::get_unassigned_segments_from_table(table);
 
@@ -461,7 +461,7 @@ impl ReaderGroupState {
             "Offset".to_owned(),
             Box::new(offset.to_owned()),
         );
-        Ok(None)
+        Ok(())
     }
 
     /// Remove the completed segments and add its successors for next to read.

--- a/src/segment/reactor.rs
+++ b/src/segment/reactor.rs
@@ -53,7 +53,7 @@ impl Reactor {
                 let event_segment_writer = selector.get_segment_writer(&pending_event.routing_key);
 
                 if let Err(e) = event_segment_writer.write(pending_event, cap_guard).await {
-                    warn!("failed to write append to segment due to {:?}, reconnecting", e);
+                    info!("failed to write append to segment due to {:?}, reconnecting", e);
                     event_segment_writer.reconnect(factory).await;
                 }
                 Ok(())
@@ -80,7 +80,7 @@ impl Reactor {
                     // cause InvalidEventNumber error.
                     if write_half.get_id() == writer_info.connection_id && writer_info.writer_id == writer.id
                     {
-                        warn!("reconnect for writer {:?}", writer_info);
+                        info!("reconnect for writer {:?}", writer_info);
                         writer.reconnect(factory).await;
                     } else {
                         info!("reconnect signal received for writer: {:?}, but does not match current writer: id {}, connection id {}, ignore", writer_info, writer.id, write_half.get_id());
@@ -116,7 +116,7 @@ impl Reactor {
                 writer.reconnection = 0;
                 writer.ack(cmd.event_number);
                 if let Err(e) = writer.write_pending_events().await {
-                    warn!(
+                    info!(
                         "writer {:?} failed to flush data to segment {:?} due to {:?}, reconnecting",
                         writer.id, writer.segment, e
                     );
@@ -156,7 +156,7 @@ impl Reactor {
             }
 
             Replies::WrongHost(cmd) => {
-                warn!(
+                info!(
                     "wrong host {:?} : stack trace {}",
                     cmd.segment, cmd.server_stack_trace
                 );

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -37,7 +37,7 @@ use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 use tokio::select;
 use tokio::sync::oneshot;
-use tracing::{debug, error, field, info, info_span, trace, warn};
+use tracing::{debug, error, field, info, info_span, trace};
 use tracing_futures::Instrument;
 
 pub(crate) struct SegmentWriter {
@@ -147,7 +147,7 @@ impl SegmentWriter {
                 match raw_client.send_setup_request(&request).await {
                     Ok((reply, connection)) => RetryResult::Success((reply, connection)),
                     Err(e) => {
-                        warn!("failed to setup append using rawclient due to {:?}", e);
+                        info!("failed to setup append using rawclient due to {:?}", e);
                         RetryResult::Retry(e)
                     }
                 }
@@ -165,7 +165,7 @@ impl SegmentWriter {
                         connection
                     }
                     _ => {
-                        warn!("append setup failed due to {:?}", reply);
+                        info!("append setup failed due to {:?}", reply);
                         return Err(SegmentWriterError::WrongReply {
                             expected: String::from("AppendSetup"),
                             actual: reply,
@@ -203,7 +203,7 @@ impl SegmentWriter {
                         let reply = match result {
                             Ok(reply) => reply,
                             Err(e) => {
-                                warn!("connection failed to read data back from segmentstore due to {:?}, closing listener task {:?}", e, listener_id);
+                                info!("connection failed to read data back from segmentstore due to {:?}, closing listener task {:?}", e, listener_id);
                                 let result = sender
                                     .send((Incoming::Reconnect(WriterInfo {
                                         segment: segment.clone(),

--- a/src/sync/synchronizer.rs
+++ b/src/sync/synchronizer.rs
@@ -771,7 +771,9 @@ async fn conditionally_write<R>(
             }
         }
     }
-    update_result.ok_or(SynchronizerError::SyncUpdateError { error_msg: "No attempts were made.".into()})
+    update_result.ok_or(SynchronizerError::SyncUpdateError {
+        error_msg: "No attempts were made.".into(),
+    })
 }
 
 async fn conditionally_remove<R>(
@@ -840,7 +842,9 @@ async fn conditionally_remove<R>(
             }
         }
     }
-    delete_result.ok_or(SynchronizerError::SyncUpdateError { error_msg: "No attempts were made.".into()})
+    delete_result.ok_or(SynchronizerError::SyncUpdateError {
+        error_msg: "No attempts were made.".into(),
+    })
 }
 
 async fn clear_tombstone(

--- a/src/sync/synchronizer.rs
+++ b/src/sync/synchronizer.rs
@@ -298,19 +298,19 @@ impl Synchronizer {
 
     /// Insert/Update a list of keys and applies it atomically to the local map.
     /// This will update the local map to the latest version.
-    pub async fn insert(
+    pub async fn insert<R>(
         &mut self,
-        updates_generator: impl FnMut(&mut Update) -> Result<Option<String>, SynchronizerError>,
-    ) -> Result<Option<String>, SynchronizerError> {
+        updates_generator: impl FnMut(&mut Update) -> Result<R, SynchronizerError>,
+    ) -> Result<R, SynchronizerError> {
         conditionally_write(updates_generator, self, MAX_RETRIES).await
     }
 
     /// Remove a list of keys and apply it atomically to local map.
     /// This will update the local map to latest version.
-    pub async fn remove(
+    pub async fn remove<R>(
         &mut self,
-        deletes_generator: impl FnMut(&mut Update) -> Result<Option<String>, SynchronizerError>,
-    ) -> Result<Option<String>, SynchronizerError> {
+        deletes_generator: impl FnMut(&mut Update) -> Result<R, SynchronizerError>,
+    ) -> Result<R, SynchronizerError> {
         conditionally_remove(deletes_generator, self, MAX_RETRIES).await
     }
 }
@@ -702,11 +702,11 @@ where
     serde_cbor::de::from_slice(reader)
 }
 
-async fn conditionally_write(
-    mut updates_generator: impl FnMut(&mut Update) -> Result<Option<String>, SynchronizerError>,
+async fn conditionally_write<R>(
+    mut updates_generator: impl FnMut(&mut Update) -> Result<R, SynchronizerError>,
     table_synchronizer: &mut Synchronizer,
     mut retry: i32,
-) -> Result<Option<String>, SynchronizerError> {
+) -> Result<R, SynchronizerError> {
     let mut update_result = None;
 
     while retry > 0 {
@@ -720,7 +720,7 @@ async fn conditionally_write(
             remove: Vec::new(),
         };
 
-        update_result = updates_generator(&mut to_update)?;
+        update_result = Some(updates_generator(&mut to_update)?);
         debug!("number of insert is {}", to_update.insert.len());
         if to_update.insert_is_empty() {
             debug!(
@@ -771,14 +771,14 @@ async fn conditionally_write(
             }
         }
     }
-    Ok(update_result)
+    update_result.ok_or(SynchronizerError::SyncUpdateError { error_msg: "No attempts were made.".into()})
 }
 
-async fn conditionally_remove(
-    mut delete_generator: impl FnMut(&mut Update) -> Result<Option<String>, SynchronizerError>,
+async fn conditionally_remove<R>(
+    mut delete_generator: impl FnMut(&mut Update) -> Result<R, SynchronizerError>,
     table_synchronizer: &mut Synchronizer,
     mut retry: i32,
-) -> Result<Option<String>, SynchronizerError> {
+) -> Result<R, SynchronizerError> {
     let mut delete_result = None;
 
     while retry > 0 {
@@ -791,7 +791,7 @@ async fn conditionally_remove(
             insert: Vec::new(),
             remove: Vec::new(),
         };
-        delete_result = delete_generator(&mut to_delete)?;
+        delete_result = Some(delete_generator(&mut to_delete)?);
 
         if to_delete.remove_is_empty() {
             debug!(
@@ -840,13 +840,13 @@ async fn conditionally_remove(
             }
         }
     }
-    Ok(delete_result)
+    delete_result.ok_or(SynchronizerError::SyncUpdateError { error_msg: "No attempts were made.".into()})
 }
 
 async fn clear_tombstone(
     to_remove: &mut Update,
     table_synchronizer: &mut Synchronizer,
-) -> Result<Option<String>, SynchronizerError> {
+) -> Result<(), SynchronizerError> {
     table_synchronizer
         .remove(|table| {
             for remove in to_remove.get_remove_iter() {
@@ -854,7 +854,7 @@ async fn clear_tombstone(
                     table.remove(remove.outer_key.to_owned(), remove.inner_key.to_owned());
                 }
             }
-            Ok(None)
+            Ok(())
         })
         .await
 }


### PR DESCRIPTION
**Change log description**  
ReaderGroup can mark a reader as offline.

**Purpose of the change**  
Fix #257

**What the code does**  
* Adds an API in ReaderGroup that can mark a reader as offline.
* When a reader is offline, any operations involving updating the reader group state will returns an error.
* Public API that has changed are  `acquire_segment`, `reader_offline`, `release_segment`, `release_segment_at`.
* Adds a new public API `segment_start_offset` to get the latest starting offset for each segment.
* Applications that encounter this error should call `reader.segment_start_offset()` to get the latest starting offset for each segment. Those offsets are useful since any events prior to those offsets is persisted and shared by other threads, any events after those offsets should be discarded if they have been processed by applications. 

**How to verify it**  
new tests should pass
