### PR TITLE
Issue 274: Remove openssl

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -20,7 +20,7 @@ derive_builder = "0.9"
 getset = "0.0.9"
 serde_json = "1.0"
 serde = "1.0"
-reqwest = { version = "0.11", features = ["json"]}
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"]}
 base64 = "0.12"
 tokio = "1.1"
 async-trait = "0.1"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -34,4 +34,4 @@ tracing = "0.1"
 flate2 = "1.0"
 tar = "0.4"
 pkg-config = "0.3"
-reqwest = {version = "0.11", features = ["blocking"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "rustls-tls"]}


### PR DESCRIPTION
**Change log description**  
Reqwest is using openssl by default, we can change it to use rustls.

**Purpose of the change**  
Fix #274

**What the code does**  
Use rustls instead of openssl.

**How to verify it**  
current test should pass
