### PR TITLE
Issue 284: Enable list scopes API.

### DIFF
--- a/controller-client/src/cli.rs
+++ b/controller-client/src/cli.rs
@@ -50,6 +50,8 @@ enum Command {
         #[structopt(help = "Stream Name")]
         stream_name: String,
     },
+    /// List Scopes
+    ListScopes,
     /// List Streams under a scope
     ListStreams {
         #[structopt(help = "Scope Name")]
@@ -136,6 +138,22 @@ fn main() {
             let scoped_stream = ScopedStream::new(scope_name.into(), stream_name.into());
             let result = rt.block_on(controller_client.delete_stream(&scoped_stream));
             println!("Delete stream status {:?}", result);
+        }
+        Command::ListScopes => {
+            use futures::future;
+            use futures::stream::StreamExt;
+            use pravega_controller_client::paginator::list_scopes;
+
+            let stream = list_scopes(&controller_client);
+            println!("Listing scopes");
+            rt.block_on(stream.for_each(|stream| {
+                if stream.is_ok() {
+                    println!("{:?}", stream.unwrap());
+                } else {
+                    println!("Error while fetching data from Controller. Details: {:?}", stream);
+                }
+                future::ready(())
+            }));
         }
         Command::ListStreams { scope_name } => {
             use futures::future;

--- a/controller-client/src/cli.rs
+++ b/controller-client/src/cli.rs
@@ -146,11 +146,11 @@ fn main() {
 
             let stream = list_scopes(&controller_client);
             println!("Listing scopes");
-            rt.block_on(stream.for_each(|stream| {
-                if stream.is_ok() {
-                    println!("{:?}", stream.unwrap());
+            rt.block_on(stream.for_each(|scope| {
+                if scope.is_ok() {
+                    println!("{:?}", scope.unwrap());
                 } else {
-                    println!("Error while fetching data from Controller. Details: {:?}", stream);
+                    println!("Error while fetching data from Controller. Details: {:?}", scope);
                 }
                 future::ready(())
             }));

--- a/controller-client/src/cli.rs
+++ b/controller-client/src/cli.rs
@@ -70,7 +70,7 @@ enum Command {
 #[structopt(
     name = "Controller CLI",
     about = "Command line used to perform operations on the Pravega controller",
-    version = "0.1"
+    version = "0.2"
 )]
 struct Opt {
     /// Used to configure controller grpc, default uri tcp://127.0.0.1:9090

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -37,10 +37,10 @@ use controller::{
     scale_status_response, txn_state, txn_status, update_stream_status, ContinuationToken, CreateScopeStatus,
     CreateStreamStatus, CreateTxnRequest, CreateTxnResponse, DelegationToken, DeleteScopeStatus,
     DeleteStreamStatus, GetEpochSegmentsRequest, GetSegmentsRequest, NodeUri, PingTxnRequest, PingTxnStatus,
-    ScaleRequest, ScaleResponse, ScaleStatusRequest, ScaleStatusResponse, ScopeInfo, SegmentId,
-    SegmentRanges, SegmentsAtTime, StreamConfig, StreamInfo, StreamsInScopeRequest, StreamsInScopeResponse,
-    StreamsInScopeWithTagRequest, SuccessorResponse, TxnId, TxnRequest, TxnState, TxnStatus,
-    UpdateStreamStatus,
+    ScaleRequest, ScaleResponse, ScaleStatusRequest, ScaleStatusResponse, ScopeInfo, ScopesRequest,
+    ScopesResponse, SegmentId, SegmentRanges, SegmentsAtTime, StreamConfig, StreamInfo,
+    StreamsInScopeRequest, StreamsInScopeResponse, StreamsInScopeWithTagRequest, SuccessorResponse, TxnId,
+    TxnRequest, TxnState, TxnStatus, UpdateStreamStatus,
 };
 use im::{HashMap as ImHashMap, OrdMap};
 use ordered_float::OrderedFloat;
@@ -136,6 +136,12 @@ pub trait ControllerClient: Send + Sync {
      * controller executed the operation.
      */
     async fn create_scope(&self, scope: &Scope) -> ResultRetry<bool>;
+
+    /**
+     * API to list scopes given a continuation token..
+     * Use the pravega_controller_client::paginator::list_scopes to paginate over all the scopes.
+     */
+    async fn list_scopes(&self, token: &CToken) -> ResultRetry<Option<(Vec<Scope>, CToken)>>;
 
     /**
      * API to list streams under a given scope and continuation token.
@@ -387,6 +393,13 @@ impl ControllerClient for ControllerClientImpl {
         wrap_with_async_retry!(
             self.config.retry_policy.max_tries(MAX_RETRIES),
             self.call_create_scope(scope)
+        )
+    }
+
+    async fn list_scopes(&self, token: &CToken) -> ResultRetry<Option<(Vec<Scope>, CToken)>> {
+        wrap_with_async_retry!(
+            self.config.retry_policy.max_tries(MAX_RETRIES),
+            self.call_list_scopes(token)
         )
     }
 
@@ -721,6 +734,48 @@ impl ControllerClientImpl {
             operation: operation_name.to_string(),
             error_msg: format!("{:?}", retry_error),
         })
+    }
+
+    async fn call_list_scopes(&self, token: &CToken) -> Result<Option<(Vec<Scope>, CToken)>> {
+        let operation_name = "ListScopes";
+        let request: ScopesRequest = ScopesRequest {
+            continuation_token: Some(ContinuationToken::from(token)),
+        };
+        debug!("Triggering a request to the controller to list scopes");
+
+        let op_status: StdResult<tonic::Response<ScopesResponse>, tonic::Status> =
+            self.get_controller_client().await.list_scopes(request).await;
+        match op_status {
+            Ok(scopes_with_token) => {
+                let result = scopes_with_token.into_inner();
+                let mut t: Vec<String> = result.scopes;
+                if t.is_empty() {
+                    // Empty result from the controller implies no further streams present.
+                    Ok(None)
+                } else {
+                    // update state with the new set of scopes.
+                    let scopes_list: Vec<Scope> = t.drain(..).map(|i| Scope::from(i)).collect();
+                    let token: Option<ContinuationToken> = result.continuation_token;
+                    match token.map(|t| t.token) {
+                        None => {
+                            warn!("None returned for continuation token list scopes API");
+                            Err(ControllerError::InvalidResponse {
+                                can_retry: false,
+                                error_msg: "No continuation token received from Controller".to_string(),
+                            })
+                        }
+                        Some(ct) => {
+                            debug!("Returned token {} for list scopes API", ct);
+                            Ok(Some((scopes_list, CToken::from(ct.as_str()))))
+                        }
+                    }
+                }
+            }
+            Err(status) => {
+                debug!("Error {} while listing scopes", status);
+                Err(self.map_grpc_error(operation_name, status).await)
+            }
+        }
     }
 
     async fn call_list_streams(

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -77,6 +77,14 @@ impl ControllerClient for MockController {
         Ok(true)
     }
 
+    async fn check_scope_exists(&self, scope: &Scope) -> Result<bool, RetryError<ControllerError>> {
+        let scope_name = scope.name.clone();
+        if self.created_scopes.read().await.contains_key(&scope_name) {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     async fn list_scopes(
         &self,
         _token: &CToken,
@@ -218,6 +226,13 @@ impl ControllerClient for MockController {
             create_segment(segment_name, self, false).await?;
         }
         Ok(true)
+    }
+
+    async fn check_stream_exists(&self, stream: &ScopedStream) -> Result<bool, RetryError<ControllerError>> {
+        if self.created_streams.read().await.contains_key(stream) {
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     async fn update_stream(

--- a/controller-client/src/mock_controller.rs
+++ b/controller-client/src/mock_controller.rs
@@ -77,6 +77,19 @@ impl ControllerClient for MockController {
         Ok(true)
     }
 
+    async fn list_scopes(
+        &self,
+        _token: &CToken,
+    ) -> Result<Option<(Vec<Scope>, CToken)>, RetryError<ControllerError>> {
+        let map_guard = self.created_scopes.read().await;
+        let scopes = map_guard.keys();
+        let mut result = Vec::new();
+        for scope in scopes {
+            result.push(Scope::from(scope.clone()));
+        }
+        Ok(Some((result, CToken::from("mock_token"))))
+    }
+
     async fn list_streams(
         &self,
         scope: &Scope,

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -36,7 +36,7 @@ use tracing::info;
 /// let stream = list_scopes(
 ///     controller_client,
 /// );
-/// // collect all the Streams in a single vector
+/// // collect all the Scopes in a single vector
 /// let scope_list:Vec<Scope> = stream.map(|str| str.unwrap()).collect::<Vec<Scope>>().await;
 /// # }
 /// ```

--- a/controller-client/src/paginator.rs
+++ b/controller-client/src/paginator.rs
@@ -26,7 +26,7 @@ use tracing::info;
 ///```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
+/// # use pravega_controller_client::ControllerClient;
 /// # async fn call_list_scope(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
@@ -45,7 +45,7 @@ use tracing::info;
 /// ```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
+/// # use pravega_controller_client::ControllerClient;
 /// # async fn call_list_scope(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
@@ -117,7 +117,7 @@ pub fn list_scopes(
 ///```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
+/// # use pravega_controller_client::ControllerClient;
 /// # async fn call_list_stream(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
@@ -139,7 +139,7 @@ pub fn list_scopes(
 /// ```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
+/// # use pravega_controller_client::ControllerClient;
 /// # async fn call_list_stream(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
@@ -226,8 +226,8 @@ pub fn list_streams(
 /// ```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
-/// # async fn call_list_stream(controller_client: &dyn ControllerClient) {
+/// # use pravega_controller_client::ControllerClient;
+/// # async fn call_list_stream_for_tag(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
 /// use futures::future;
@@ -249,8 +249,8 @@ pub fn list_streams(
 /// ```
 /// # use tonic::transport::Channel;
 /// # use pravega_controller_client::controller::controller_service_client::ControllerServiceClient;
-/// use pravega_controller_client::ControllerClient;
-/// # async fn call_list_stream(controller_client: &dyn ControllerClient) {
+/// # use pravega_controller_client::ControllerClient;
+/// # async fn call_list_stream_for_tag(controller_client: &dyn ControllerClient) {
 /// use pravega_client_shared::Scope;
 /// use pravega_client_shared::ScopedStream;
 /// use futures::future;

--- a/integration_test/src/controller_tests.rs
+++ b/integration_test/src/controller_tests.rs
@@ -48,6 +48,15 @@ pub async fn test_scope_stream(controller: &dyn ControllerClient) {
     assert!(scopes.contains(&scope1));
     assert!(scopes.contains(&scope2));
 
+    assert!(controller
+        .check_scope_exists(&scope1)
+        .await
+        .expect("check scope exists"));
+    assert!(!controller
+        .check_scope_exists(&Scope::from("dummy".to_string()))
+        .await
+        .expect("check scope exists"));
+
     controller
         .create_scope(&scope3)
         .await
@@ -72,6 +81,10 @@ pub async fn test_scope_stream(controller: &dyn ControllerClient) {
         scope: scope3.clone(),
         stream: Stream::from("st1".to_string()),
     };
+    assert!(!controller
+        .check_stream_exists(&st1)
+        .await
+        .expect("Check stream exists"));
     let stream_cfg = StreamConfiguration {
         scoped_stream: st1.clone(),
         scaling: Default::default(),
@@ -80,6 +93,10 @@ pub async fn test_scope_stream(controller: &dyn ControllerClient) {
     };
 
     let _stream_result = controller.create_stream(&stream_cfg).await;
+    assert!(controller
+        .check_stream_exists(&st1)
+        .await
+        .expect("Check stream exists"));
     let streams = get_all_streams(controller, &scope3).await;
     // _Mark stream is also created.
     assert_eq!(streams.len(), 2);

--- a/integration_test/src/controller_tests.rs
+++ b/integration_test/src/controller_tests.rs
@@ -33,9 +33,57 @@ pub fn test_controller_apis(config: PravegaStandaloneServiceConfig) {
     // Create a Scope that is used by all the tests.
     let scope_result = handle.block_on(controller.create_scope(&Scope::from(SCOPE.to_owned())));
     info!("Response for create_scope is {:?}", scope_result);
-    // Inovke the tests.
+    // Invoke the tests.
+    handle.block_on(test_scope_stream(controller));
     handle.block_on(test_stream_tags(controller));
-    //handle.block_on(test_scale_stream(controller));
+    handle.block_on(test_scale_stream(controller));
+}
+
+pub async fn test_scope_stream(controller: &dyn ControllerClient) {
+    let scopes = get_all_scopes(controller).await;
+    let scope1 = Scope::from(SCOPE.to_string());
+    let scope2 = Scope::from("_system".to_string());
+    let scope3 = Scope::from("sc1".to_string());
+    let scope4 = Scope::from("sc2".to_string());
+    assert!(scopes.contains(&scope1));
+    assert!(scopes.contains(&scope2));
+
+    controller
+        .create_scope(&scope3)
+        .await
+        .expect("Creating scope sc1");
+
+    controller
+        .create_scope(&scope4)
+        .await
+        .expect("Creating scope sc2");
+
+    let scopes = get_all_scopes(controller).await;
+    assert_eq!(scopes.len(), 4);
+    assert!(scopes.contains(&scope1));
+    assert!(scopes.contains(&scope2));
+    assert!(scopes.contains(&scope3));
+    assert!(scopes.contains(&scope4));
+
+    let streams = get_all_streams(controller, &scope3).await;
+    assert_eq!(streams.len(), 0);
+
+    let st1 = ScopedStream {
+        scope: scope3.clone(),
+        stream: Stream::from("st1".to_string()),
+    };
+    let stream_cfg = StreamConfiguration {
+        scoped_stream: st1.clone(),
+        scaling: Default::default(),
+        retention: Default::default(),
+        tags: Some(vec!["tag1".to_string(), "tag2".to_string()]),
+    };
+
+    let _stream_result = controller.create_stream(&stream_cfg).await;
+    let streams = get_all_streams(controller, &scope3).await;
+    // _Mark stream is also created.
+    assert_eq!(streams.len(), 2);
+    assert!(streams.contains(&st1));
 }
 
 pub async fn test_stream_tags(controller: &dyn ControllerClient) {
@@ -142,6 +190,30 @@ async fn get_all_streams_for_tag(
         .await
         .unwrap()
     {
+        result.append(&mut res);
+        token = next_token;
+    }
+    result
+}
+
+// Helper method to fetch all the scopes.
+async fn get_all_scopes(controller: &dyn ControllerClient) -> Vec<Scope> {
+    let mut result: Vec<Scope> = Vec::new();
+
+    let mut token = CToken::empty();
+    while let Some((mut res, next_token)) = controller.list_scopes(&token).await.unwrap() {
+        result.append(&mut res);
+        token = next_token;
+    }
+    result
+}
+
+// Helper method to fetch all the streams for a tag.
+async fn get_all_streams(controller: &dyn ControllerClient, scope_name: &Scope) -> Vec<ScopedStream> {
+    let mut result: Vec<ScopedStream> = Vec::new();
+
+    let mut token = CToken::empty();
+    while let Some((mut res, next_token)) = controller.list_streams(&scope_name, &token).await.unwrap() {
         result.append(&mut res);
         token = next_token;
     }

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -94,20 +94,20 @@ mod test {
             .unwrap();
 
         // metric::metric_init(PROMETHEUS_SCRAPE_PORT.parse::<SocketAddr>().unwrap());
-        info!("Running integration test");
-        let config = PravegaStandaloneServiceConfig::new(false, true, true);
-        run_tests(config);
+        // info!("Running integration test");
+        // let config = PravegaStandaloneServiceConfig::new(false, true, true);
+        // run_tests(config);
 
         let config = PravegaStandaloneServiceConfig::new(true, false, false);
         run_tests(config);
 
-        // disconnection test will start its own Pravega Standalone.
-        disconnection_tests::disconnection_test_wrapper();
+        // // disconnection test will start its own Pravega Standalone.
+        // disconnection_tests::disconnection_test_wrapper();
     }
 
     fn run_tests(config: PravegaStandaloneServiceConfig) {
-        let mut pravega = PravegaStandaloneService::start(config.clone());
-        wait_for_standalone_with_timeout(true, 30);
+        // let mut pravega = PravegaStandaloneService::start(config.clone());
+        // wait_for_standalone_with_timeout(true, 30);
         if config.auth {
             env::set_var("pravega_client_auth_method", "Basic");
             env::set_var("pravega_client_auth_username", "admin");
@@ -118,38 +118,38 @@ mod test {
             info!("Running controller test");
             controller_tests::test_controller_apis(config.clone());
         });
-        let span = info_span!("table map test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running table map test");
-            table_tests::test_table(config.clone());
-        });
-        let span = info_span!("event stream writer test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running event stream writer test");
-            event_writer_tests::test_event_stream_writer(config.clone());
-        });
-        let span = info_span!("synchronizer test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running synchronizer test");
-            synchronizer_tests::test_tablesynchronizer(config.clone());
-        });
-        let span = info_span!("transaction test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running transaction test");
-            transactional_event_writer_tests::test_transactional_event_stream_writer(config.clone());
-        });
-        let span = info_span!("byte stream test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running byte stream test");
-            byte_reader_writer_tests::test_byte_stream(config.clone());
-        });
-        let span = info_span!("event reader test", auth = config.auth, tls = config.tls);
-        span.in_scope(|| {
-            info!("Running event reader test");
-            event_reader_tests::test_event_stream_reader(config.clone());
-        });
-        // Shut down Pravega standalone
-        pravega.stop().unwrap();
-        wait_for_standalone_with_timeout(false, 30);
+        // let span = info_span!("table map test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running table map test");
+        //     table_tests::test_table(config.clone());
+        // });
+        // let span = info_span!("event stream writer test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running event stream writer test");
+        //     event_writer_tests::test_event_stream_writer(config.clone());
+        // });
+        // let span = info_span!("synchronizer test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running synchronizer test");
+        //     synchronizer_tests::test_tablesynchronizer(config.clone());
+        // });
+        // let span = info_span!("transaction test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running transaction test");
+        //     transactional_event_writer_tests::test_transactional_event_stream_writer(config.clone());
+        // });
+        // let span = info_span!("byte stream test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running byte stream test");
+        //     byte_reader_writer_tests::test_byte_stream(config.clone());
+        // });
+        // let span = info_span!("event reader test", auth = config.auth, tls = config.tls);
+        // span.in_scope(|| {
+        //     info!("Running event reader test");
+        //     event_reader_tests::test_event_stream_reader(config.clone());
+        // });
+        // // Shut down Pravega standalone
+        // pravega.stop().unwrap();
+        // wait_for_standalone_with_timeout(false, 30);
     }
 }

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -94,20 +94,20 @@ mod test {
             .unwrap();
 
         // metric::metric_init(PROMETHEUS_SCRAPE_PORT.parse::<SocketAddr>().unwrap());
-        // info!("Running integration test");
-        // let config = PravegaStandaloneServiceConfig::new(false, true, true);
-        // run_tests(config);
+        info!("Running integration test");
+        let config = PravegaStandaloneServiceConfig::new(false, true, true);
+        run_tests(config);
 
         let config = PravegaStandaloneServiceConfig::new(true, false, false);
         run_tests(config);
 
-        // // disconnection test will start its own Pravega Standalone.
-        // disconnection_tests::disconnection_test_wrapper();
+        // disconnection test will start its own Pravega Standalone.
+        disconnection_tests::disconnection_test_wrapper();
     }
 
     fn run_tests(config: PravegaStandaloneServiceConfig) {
-        // let mut pravega = PravegaStandaloneService::start(config.clone());
-        // wait_for_standalone_with_timeout(true, 30);
+        let mut pravega = PravegaStandaloneService::start(config.clone());
+        wait_for_standalone_with_timeout(true, 30);
         if config.auth {
             env::set_var("pravega_client_auth_method", "Basic");
             env::set_var("pravega_client_auth_username", "admin");
@@ -118,38 +118,38 @@ mod test {
             info!("Running controller test");
             controller_tests::test_controller_apis(config.clone());
         });
-        // let span = info_span!("table map test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running table map test");
-        //     table_tests::test_table(config.clone());
-        // });
-        // let span = info_span!("event stream writer test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running event stream writer test");
-        //     event_writer_tests::test_event_stream_writer(config.clone());
-        // });
-        // let span = info_span!("synchronizer test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running synchronizer test");
-        //     synchronizer_tests::test_tablesynchronizer(config.clone());
-        // });
-        // let span = info_span!("transaction test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running transaction test");
-        //     transactional_event_writer_tests::test_transactional_event_stream_writer(config.clone());
-        // });
-        // let span = info_span!("byte stream test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running byte stream test");
-        //     byte_reader_writer_tests::test_byte_stream(config.clone());
-        // });
-        // let span = info_span!("event reader test", auth = config.auth, tls = config.tls);
-        // span.in_scope(|| {
-        //     info!("Running event reader test");
-        //     event_reader_tests::test_event_stream_reader(config.clone());
-        // });
-        // // Shut down Pravega standalone
-        // pravega.stop().unwrap();
-        // wait_for_standalone_with_timeout(false, 30);
+        let span = info_span!("table map test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running table map test");
+            table_tests::test_table(config.clone());
+        });
+        let span = info_span!("event stream writer test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running event stream writer test");
+            event_writer_tests::test_event_stream_writer(config.clone());
+        });
+        let span = info_span!("synchronizer test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running synchronizer test");
+            synchronizer_tests::test_tablesynchronizer(config.clone());
+        });
+        let span = info_span!("transaction test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running transaction test");
+            transactional_event_writer_tests::test_transactional_event_stream_writer(config.clone());
+        });
+        let span = info_span!("byte stream test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running byte stream test");
+            byte_reader_writer_tests::test_byte_stream(config.clone());
+        });
+        let span = info_span!("event reader test", auth = config.auth, tls = config.tls);
+        span.in_scope(|| {
+            info!("Running event reader test");
+            event_reader_tests::test_event_stream_reader(config.clone());
+        });
+        // Shut down Pravega standalone
+        pravega.stop().unwrap();
+        wait_for_standalone_with_timeout(false, 30);
     }
 }


### PR DESCRIPTION
**Change log description**  
Enable the following controller APIs
   *  listScopes
   *  checkScopeExists
   *  checkStreamExists

**Purpose of the change**  
Fixes #284 

**What the code does**  
Enable the below 3 controller APIs
```
   rpc listScopes(ScopesRequest) returns (ScopesResponse);
   rpc checkScopeExists(ScopeInfo) returns (ExistsResponse);
   rpc checkStreamExists(StreamInfo) returns (ExistsResponse);
```
Enable List Scopes in Controller CLI
```bash
osboxes@osboxes:~$ ./controller-cli list-scopes --help
controller-cli-list-scopes 0.2.0
List Scopes

USAGE:
    controller-cli list-scopes

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

```
**How to verify it**  
All the existing and newly added tests should continue to pass.
