### PR TITLE
Issue 269: Update maturin.

### DIFF
--- a/.github/workflows/build_wheel.py
+++ b/.github/workflows/build_wheel.py
@@ -12,16 +12,12 @@ ROOT = Path(__file__).parent.parent.parent
 # this script.
 # Note the docker image konstin2/maturin:master does not work.
 
-# manylinux is set to unchecked due to the below error
-# Your library is not manylinux compliant because it links the following forbidden libraries: ["libssl.so.1.1", "libcrypto.so.1.1"]
 os.chdir("./python_binding")
 command = [
     "maturin",
     "build",
     "--release",
     "--no-sdist",
-    "--manylinux",
-    "1-unchecked",
     "--interpreter",
     sys.executable,
 ]

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate Pravega Python API documentation.
         run: |
-          pip install 'maturin==0.8.3' virtualenv pdoc3
+          pip install 'maturin>=0.11,<0.12' virtualenv pdoc3
           virtualenv venv
           source venv/bin/activate
           maturin develop -m python_binding/Cargo.toml

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin==0.8.3' virtualenv tox
+        run: pip install 'maturin>=0.11,<0.12' virtualenv tox
       - name: Test with tox
         run: tox -c python_binding/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -35,7 +35,7 @@ jobs:
           components: rustfmt, clippy
       - run: rustup set default-host ${{ matrix.platform.rust-target }}
       - name: install maturin
-        run: pip install 'maturin==0.8.3'
+        run: pip install 'maturin>=0.11,<0.12'
       - name: build wheel
         id: build_wheel
         run: python -u .github/workflows/build_wheel.py

--- a/python_binding/Cargo.toml
+++ b/python_binding/Cargo.toml
@@ -13,8 +13,9 @@ authors = ["Pravega Community"]
 [package.metadata.maturin]
 classifier = ["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Rust", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9",]
-requires-python = ">= 3.8"
-project-url = ["Homepage, https://pravega.github.io/pravega-client-rust/"]
+requires-python = ">=3.8"
+[package.metadata.maturin.project-url]
+Homepage= "https://pravega.github.io/pravega-client-rust/"
 
 [lib]
 name = "pravega_client"

--- a/python_binding/pyproject.toml
+++ b/python_binding/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
-requires = ["maturin==0.8.3"]
+requires = ["maturin>=0.11,<0.12"]
 build-backend = "maturin"
+


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**  
Update maturin tool from 0.8.3 to 0.11.0

**Purpose of the change**  
Fixes #269 

**What the code does**  
Update maturin tool from `0.8.3` to `0.11.0`.
Verified that the python packages generated with the latest version of maturin are manylinux compliant. Non compliant whl packages cannot be uploaded to pypi repository. The fix of removing open ssl dependency simplified this upgrade.

**How to verify it**  
All the existing tests should continue to pass.
