### PR TITLE
Issue 292: Fix transaction id format error

### DIFF
--- a/integration_test/src/transactional_event_writer_tests.rs
+++ b/integration_test/src/transactional_event_writer_tests.rs
@@ -57,11 +57,12 @@ pub fn test_transactional_event_stream_writer(config: PravegaStandaloneServiceCo
     ));
 
     let mut writer =
-        handle.block_on(client_factory.create_transactional_event_writer(scoped_stream, WriterId(0)));
+        handle.block_on(client_factory.create_transactional_event_writer(scoped_stream.clone(), WriterId(0)));
 
     handle.block_on(test_commit_transaction(&mut writer));
     handle.block_on(test_abort_transaction(&mut writer));
     handle.block_on(test_write_and_read_transaction(&mut writer, &client_factory));
+    handle.block_on(test_multiple_transactions(&client_factory, scoped_stream));
 
     info!("test TransactionalEventStreamWriter passed");
 }

--- a/integration_test/src/transactional_event_writer_tests.rs
+++ b/integration_test/src/transactional_event_writer_tests.rs
@@ -174,6 +174,44 @@ async fn test_write_and_read_transaction(writer: &mut TransactionalEventWriter, 
     info!("test write transaction passed");
 }
 
+async fn test_multiple_transactions(factory: &ClientFactory, stream: ScopedStream) {
+    // multiple transaction writers
+    let mut transactions = vec![];
+    let mut transaction_writers = vec![];
+    for writer_id in 1..100 {
+        let mut transaction_writer = factory
+            .create_transactional_event_writer(stream.clone(), WriterId(writer_id as u128))
+            .await;
+        let transaction = transaction_writer.begin().await.expect("begin transaction");
+        transaction_writers.push(transaction_writer);
+        transactions.push(transaction);
+    }
+
+    for mut transaction in transactions {
+        let event = vec![1; 100];
+        transaction.write_event(None, event).await.expect("write event");
+        let timestamp = Timestamp { 0: 0 };
+        transaction.commit(timestamp).await.expect("commit");
+    }
+
+    // one transaction writer with multiple transactions
+    let mut transactions = vec![];
+    let mut transaction_writer = factory
+        .create_transactional_event_writer(stream.clone(), WriterId(100))
+        .await;
+    for _i in 0..100 {
+        let transaction = transaction_writer.begin().await.expect("begin transaction");
+        transactions.push(transaction);
+    }
+
+    for mut transaction in transactions {
+        let event = vec![1; 100];
+        transaction.write_event(None, event).await.expect("write event");
+        let timestamp = Timestamp { 0: 0 };
+        transaction.commit(timestamp).await.expect("commit");
+    }
+}
+
 // helper function
 async fn setup_test(scope_name: &Scope, stream_name: &Stream, controller_client: &dyn ControllerClient) {
     controller_client

--- a/shared/src/naming_utils.rs
+++ b/shared/src/naming_utils.rs
@@ -42,8 +42,8 @@ impl NameUtils {
                 "{}{}{}{}",
                 segment_name,
                 TRANSACTION_DELIMITER,
-                format!("{:016X}", (transaction_id.0 >> 64) as i64),
-                format!("{:016X}", transaction_id.0 as i64)
+                format!("{:016x}", (transaction_id.0 >> 64) as i64),
+                format!("{:016x}", transaction_id.0 as i64)
             )
         } else {
             segment_name

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -393,14 +393,14 @@ impl SegmentWriter {
         ret
     }
 
-    /// Reconnect will not exist until this writer has been successfully connected to the right host.
+    /// Reconnection will not exit until this writer has been successfully connected to the right host.
     ///
     /// It does the following steps:
     /// 1. sets up a new connection
     /// 2. puts inflight events back to the pending list
     /// 3. writes pending data to the server
     ///
-    /// If error occurs during any one of the steps above, redo the reconnect from step 1.
+    /// If error occurs during any one of the steps above, redo the reconnection from step 1.
     pub(crate) async fn reconnect(&mut self, factory: &ClientFactory) {
         debug!("Reconnecting segment writer {:?}", self.id);
         let connection_id = if let Some(ref write_half) = self.connection {


### PR DESCRIPTION
**Change log description**  
The hexadecimal based transaction id was using upper case letter whereas lower case letter should be used.

**What the code does**  
use lower case letter

**How to verify it**  
test should pass
