### PR TITLE
Issue 239: Add flush for event writer

### DIFF
--- a/book/src/Python/PythonBindings.md
+++ b/book/src/Python/PythonBindings.md
@@ -71,7 +71,9 @@ e_bytes=e.encode("utf-8")
 # write into Pravega stream without specifying the routing key.    
 writer.write_event_bytes(e_bytes)                                    
 # write into Pravega stream by specifying the routing key.       
-writer.write_event_bytes(e_bytes, "key1")    
+writer.write_event_bytes(e_bytes, "key1")
+# flush data to Pravega
+writer.flush()
 ```
 
 ## TransactionWriter

--- a/examples/event_write_and_read.rs
+++ b/examples/event_write_and_read.rs
@@ -68,8 +68,8 @@ fn main() {
 
         // write payload
         let payload = "hello world".to_string().into_bytes();
-        let result = event_writer.write_event(payload).await;
-        assert!(result.await.is_ok());
+        event_writer.write_event(payload).await;
+        event_writer.flush().await.expect("flush");
         println!("event writer sent and flushed data");
 
         // create event stream reader

--- a/integration_test/src/event_reader_tests.rs
+++ b/integration_test/src/event_reader_tests.rs
@@ -662,8 +662,8 @@ async fn write_events(
     };
     let mut writer = client_factory.create_event_writer(scoped_stream);
     for x in 0..num_events {
-        let rx = writer.write_event(vec![1; event_size]).await;
-        rx.await.expect("Failed to write Event").unwrap();
+        writer.write_event(vec![1; event_size]).await;
+        writer.flush().await.expect("flush");
         info!("write count {}", x);
     }
 }

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -69,9 +69,9 @@ type EventHandle = oneshot::Receiver<Result<(), Error>>;
 ///     let mut event_writer = client_factory.create_event_writer(stream);
 ///
 ///     let payload = "hello world".to_string().into_bytes();
-///     let result = event_writer.write_event(payload).await;
+///     event_writer.write_event(payload).await;
+///     event_writer.flush().await.expect("flush");
 ///
-///     assert!(result.await.is_ok())
 /// }
 /// ```
 pub struct EventWriter {

--- a/src/event/writer.rs
+++ b/src/event/writer.rs
@@ -155,9 +155,10 @@ impl EventWriter {
     /// Making sure events are persisted on the server side.
     pub async fn flush(&mut self) -> Result<(), Error> {
         if let Some(event_handle) = self.event_handle.take() {
-            event_handle
+            let res = event_handle
                 .await
-                .map_err(|e| Error::new(ErrorKind::Other, format!("oneshot error {:?}", e)))?
+                .map_err(|e| Error::new(ErrorKind::Other, format!("oneshot error {:?}", e)))?;
+            res
         } else {
             Ok(())
         }

--- a/src/segment/reactor.rs
+++ b/src/segment/reactor.rs
@@ -83,7 +83,7 @@ impl Reactor {
                     // cause InvalidEventNumber error.
                     if write_half.get_id() == writer_info.connection_id && writer_info.writer_id == writer.id
                     {
-                        warn!("reconnect for writer {:?}", writer_info);
+                        info!("reconnect for writer {:?}", writer_info);
                         writer.reconnect(factory).await;
                     } else {
                         info!("reconnect signal received for writer: {:?}, but does not match current writer: id {}, connection id {}, ignore", writer_info, writer.id, write_half.get_id());

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -203,7 +203,7 @@ impl SegmentWriter {
                         let reply = match result {
                             Ok(reply) => reply,
                             Err(e) => {
-                                warn!("connection failed to read data back from segmentstore due to {:?}, closing listener task {:?}", e, listener_id);
+                                info!("connection failed to read data back from segmentstore due to {:?}, closing listener task {:?}", e, listener_id);
                                 let result = sender
                                     .send((Incoming::Reconnect(WriterInfo {
                                         segment: segment.clone(),


### PR DESCRIPTION
**Change log description**  
Add flush for event writer.

**Purpose of the change**  
Fix #239 

**What the code does**  
Add a flush method for event writer. Applications use flush to make sure events are persisted in Pravega.

**How to verify it**  
Tests should pass
