### PR TITLE
Issue 301 : Use native roots for reqwest

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -20,7 +20,7 @@ derive_builder = "0.9"
 getset = "0.0.9"
 serde_json = "1.0"
 serde = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"]}
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"]}
 base64 = "0.12"
 tokio = "1.1"
 async-trait = "0.1"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -34,4 +34,4 @@ tracing = "0.1"
 flate2 = "1.0"
 tar = "0.4"
 pkg-config = "0.3"
-reqwest = {version = "0.11", default-features = false, features = ["blocking", "rustls-tls"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "rustls-tls-native-roots"]}


### PR DESCRIPTION
**Change log description**  
Use native roots for reqwest which will auto scan the default linux cert directory. Previously, it is using root certs from webpki, so any self signed certs cannot be loaded. 

**Purpose of the change**  
Fix #301

**What the code does**  
Use native roots

**How to verify it**  
Had verified that it's working in SDP
