### PR TITLE
Issue 318: Enable users to read from Tail of Stream.

### DIFF
--- a/src/client_factory.rs
+++ b/src/client_factory.rs
@@ -41,6 +41,7 @@ use pravega_wire_protocol::connection_factory::{
 };
 
 use crate::index::{IndexReader, IndexWriter};
+use crate::util::meta::MetaClient;
 use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -270,6 +271,18 @@ impl ClientFactoryAsync {
         EventWriter::new(stream, self.clone())
     }
 
+    pub async fn create_stream_meta_client(&self, stream: ScopedStream) -> MetaClient {
+        MetaClient::new(
+            stream.clone(),
+            self.clone(),
+            self.create_delegation_token_provider(stream).await,
+        )
+    }
+
+    ///
+    /// Create a ReaderGroup with the specified name to read from the specified Stream.
+    /// The readers will read from the HEAD/beginning of the Stream.
+    ///
     pub async fn create_reader_group(&self, reader_group_name: String, stream: ScopedStream) -> ReaderGroup {
         let scope = stream.scope.clone();
         let rg_config = ReaderGroupConfigBuilder::default().add_stream(stream).build();

--- a/src/client_factory.rs
+++ b/src/client_factory.rs
@@ -15,7 +15,7 @@
 //!
 use crate::byte::reader::ByteReader;
 use crate::byte::writer::ByteWriter;
-use crate::event::reader_group::{ReaderGroup, ReaderGroupConfigBuilder};
+use crate::event::reader_group::{ReaderGroup, ReaderGroupConfig, ReaderGroupConfigBuilder};
 use crate::event::transactional_writer::TransactionalEventWriter;
 use crate::event::writer::EventWriter;
 use crate::segment::metadata::SegmentMetadataClient;
@@ -286,6 +286,18 @@ impl ClientFactoryAsync {
     pub async fn create_reader_group(&self, reader_group_name: String, stream: ScopedStream) -> ReaderGroup {
         let scope = stream.scope.clone();
         let rg_config = ReaderGroupConfigBuilder::default().add_stream(stream).build();
+        ReaderGroup::create(scope, reader_group_name, rg_config, self.clone()).await
+    }
+
+    ///
+    /// Create a ReaderGroup with the streams configured in the ReaderGroupConfig.
+    ///
+    pub async fn create_reader_group_with_config(
+        &self,
+        scope: Scope,
+        reader_group_name: String,
+        rg_config: ReaderGroupConfig,
+    ) -> ReaderGroup {
         ReaderGroup::create(scope, reader_group_name, rg_config, self.clone()).await
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -23,6 +23,7 @@ use crate::client_factory::ClientFactory;
 
 #[macro_use]
 pub(crate) mod metric;
+pub mod meta;
 pub mod oneshot_holder;
 
 thread_local! {


### PR DESCRIPTION
**Change log description**  
- Enable a Stream meta client that enables users to
1. Fetch a StreamCut pointing to the current Head of a Stream.
2. Fetch a StreamCut pointing to the current Tail of a Stream.
- Enable ReaderGroup to take the starting StreamCut.
- Externalized ReaderGroupConfig that can be used to read multiple Streams from their StreamCuts.

**Purpose of the change**  
Fixes #318 

**What the code does**  
- Enable a Stream meta client that enables users to
1. Fetch a StreamCut pointing to the current Head of a Stream.
2. Fetch a StreamCut pointing to the current Tail of a Stream.
3. Check if a Stream is sealed.
- Enable ReaderGroup to take the starting StreamCut.
- Externalized ReaderGroupConfig that can be used to read multiple Streams from their StreamCuts.
- Client Factory now enables a ReaderGroupConfig passed while creating a ReaderGroup.

- Python API changes to ensure we can read from the Tail of a Stream.(TBD)
- Use this to verify if a ByteStream is sealed.

**How to verify it**  
All the existing and newly added tests should pass. TBD: Addition of tests and verification is in progress.
