### PR TITLE
Issue 226: Add is_sealed getter in metadata

### DIFF
--- a/src/segment/metadata.rs
+++ b/src/segment/metadata.rs
@@ -111,6 +111,7 @@ impl SegmentMetadataClient {
         })
     }
 
+    /// Returns whether the current segment is sealed.
     pub async fn is_sealed(&self) -> Result<bool, SegmentMetadataClientError> {
         self.get_segment_info().await.map(|cmd| cmd.is_sealed)
     }

--- a/src/segment/metadata.rs
+++ b/src/segment/metadata.rs
@@ -111,6 +111,10 @@ impl SegmentMetadataClient {
         })
     }
 
+    pub async fn is_sealed(&self) -> Result<bool, SegmentMetadataClientError> {
+        self.get_segment_info().await.map(|cmd| cmd.is_sealed)
+    }
+
     /// Returns the length of the current segment. i.e. the total length of all data written to the segment.
     pub async fn fetch_current_segment_length(&self) -> Result<i64, SegmentMetadataClientError> {
         self.get_segment_info().await.map(|cmd| cmd.write_offset)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -72,13 +72,6 @@ impl MetadataWrapper {
             .map_err(|e| format!("{:?}", e))
     }
 
-    pub async fn is_sealed(&self) -> Result<bool, String> {
-        self.inner
-            .is_sealed()
-            .await
-            .map_err(|e| format!("{:?}", e))
-    }
-
     pub async fn fetch_current_segment_length(&self) -> Result<i64, String> {
         self.inner
             .fetch_current_segment_length()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -72,6 +72,13 @@ impl MetadataWrapper {
             .map_err(|e| format!("{:?}", e))
     }
 
+    pub async fn is_sealed(&self) -> Result<bool, String> {
+        self.inner
+            .is_sealed()
+            .await
+            .map_err(|e| format!("{:?}", e))
+    }
+
     pub async fn fetch_current_segment_length(&self) -> Result<i64, String> {
         self.inner
             .fetch_current_segment_length()


### PR DESCRIPTION
Signed-off-by: dellThejas <Thejas.Vidyasagar@dell.com>

**Change log description**  

- Added `is_sealed` getter to check if the segment has been sealed.

**Purpose of the change**  
Fixes #226 

**What the code does**  
Provides the user with information whether the segment is sealed or not.

**How to verify it**  
Existing tests continue to pass.