### PR TITLE
Issue 329: Enable dangerous feature flag

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,4 +29,4 @@ num-traits = "0.2"
 num-derive = "0.3"
 regex = "1.3"
 lazy_static = "1.4"
-tokio-rustls = "0.22.0"
+tokio-rustls = { version = "0.22.0", features = ["dangerous_configuration"] }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Prevent a compile error. 

**Purpose of the change**  
Fixes #329 

**What the code does**  
Enable dangerous feature flag on rustls to prevent a compile error. (Dangerous configuration is only enabled if explicitly set in client config)
