### PR TITLE
Issue 286: Support reconnecting when a connection was never established

### DIFF
--- a/src/segment/event.rs
+++ b/src/segment/event.rs
@@ -34,7 +34,7 @@ pub(crate) struct ServerReply {
 #[derive(new, Debug)]
 pub(crate) struct WriterInfo {
     pub(crate) segment: ScopedSegment,
-    pub(crate) connection_id: Uuid,
+    pub(crate) connection_id: Option<Uuid>,
     pub(crate) writer_id: WriterId,
 }
 

--- a/src/segment/reactor.rs
+++ b/src/segment/reactor.rs
@@ -68,6 +68,25 @@ impl Reactor {
                 }
                 Ok(())
             }
+            Incoming::Reconnect(writer_info) => {
+                let option = selector.writers.get_mut(&writer_info.segment);
+                if option.is_none() {
+                    return Ok(());
+                }
+                let writer = option.unwrap();
+
+                // Only reconnect if the current connection is having connection failure. It might happen that the
+                // write op has already triggered the connection failure and has reconnected. It's necessary to avoid
+                // reconnect twice since resending duplicate inflight events will cause InvalidEventNumber error.
+                let current_connection_id = writer.connection.as_ref().map(|c| c.get_id());
+                if current_connection_id == writer_info.connection_id {
+                    warn!("reconnect for writer {:?}", writer_info);
+                    writer.reconnect(factory).await;
+                } else {
+                    info!("reconnect signal received for writer: {:?}, but does not match current writer: id {}, connection id {:?}, ignore", writer_info, writer.id, current_connection_id);
+                }
+                Ok(())
+            }
             Incoming::ServerReply(server_reply) => {
                 if let Err(e) = Reactor::process_server_reply(server_reply, selector, factory).await {
                     error!("failed to process server reply due to {:?}", e);
@@ -75,28 +94,6 @@ impl Reactor {
                 } else {
                     Ok(())
                 }
-            }
-            Incoming::Reconnect(writer_info) => {
-                let option = selector.writers.get_mut(&writer_info.segment);
-                if option.is_none() {
-                    return Ok(());
-                }
-                let writer = option.unwrap();
-                if let Some(ref write_half) = writer.connection {
-                    // Only reconnect if the current connection is having connection
-                    // failure. It might happen that the write op has already triggered
-                    // the connection failure and has reconnected. It's necessary to avoid
-                    // reconnect twice since resending duplicate inflight events will
-                    // cause InvalidEventNumber error.
-                    if write_half.get_id() == writer_info.connection_id && writer_info.writer_id == writer.id
-                    {
-                        warn!("reconnect for writer {:?}", writer_info);
-                        writer.reconnect(factory).await;
-                    } else {
-                        info!("reconnect signal received for writer: {:?}, but does not match current writer: id {}, connection id {}, ignore", writer_info, writer.id, write_half.get_id());
-                    }
-                }
-                Ok(())
             }
             Incoming::Reset(segment) => {
                 info!("reset writer for segment {:?} in reactor", segment);

--- a/src/segment/writer.rs
+++ b/src/segment/writer.rs
@@ -212,7 +212,7 @@ impl SegmentWriter {
                                 let result = sender
                                     .send((Incoming::Reconnect(WriterInfo {
                                         segment: segment.clone(),
-                                        connection_id: r.get_id(),
+                                        connection_id: Some(r.get_id()),
                                         writer_id,
                                     }), 0)).await;
                                 if let Err(e) = result {
@@ -408,11 +408,7 @@ impl SegmentWriter {
     /// If error occurs during any one of the steps above, redo the reconnection from step 1.
     pub(crate) async fn reconnect(&mut self, factory: &ClientFactoryAsync) {
         debug!("Reconnecting segment writer {:?}", self.id);
-        let connection_id = if let Some(ref write_half) = self.connection {
-            write_half.get_id()
-        } else {
-            panic!("should always have connection here");
-        };
+        let connection_id = self.connection.as_ref().map(|c| c.get_id());
 
         // setup the connection
         let setup_res = self.setup_connection(factory).await;


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Support reconnecting when a connection was never established

**Purpose of the change**  
Fixes #286

**What the code does**  
Allows for no connection to be specified in a re-connect request. Meaning the reconnect should be attempted if there is no connection.

