### PR TITLE
Issue 337: Automate cargo publish check

### DIFF
--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -44,5 +44,4 @@ jobs:
       - name: Install cargo-release
         run: cargo install cargo-release
       - name: Release (Dry Run)
-        run: cargo release --workspace # By default cargo-release run in dry-run mode.
-
+        run: cargo release --workspace -vv --exclude pravega-client-integration-test --exclude pravega-client-examples --exclude pravegactl

--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -13,7 +13,31 @@ jobs:
     name: Run cargo-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache toolchain
+        uses: actions/cache@v1
+        with:
+          path: /usr/share/rust/.cargo
+          key: ${{ runner.os }}-rustup
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
@@ -21,4 +45,4 @@ jobs:
         run: cargo install cargo-release
       - name: Release (Dry Run)
         run: cargo release --workspace # By default cargo-release run in dry-run mode.
- 
+

--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "*"
+  pull_request:
+    branches:
+      - master
 
 jobs:
   release:
@@ -12,18 +15,10 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           override: true
       - name: Install cargo-release
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-release
-          version: 0.18.4
-      - name: Run cargo-release
-        uses: actions-rs/cargo@v1
-        with:
-          command: release
-          # By default cargo-release run in dry-run mode.
-          # args: --no-confirm --execute --no-verify --dev-version
-
+        run: cargo install cargo-release
+      - name: Release (Dry Run)
+        run: cargo release --workspace # By default cargo-release run in dry-run mode.
+ 

--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -1,0 +1,29 @@
+# This action is meant to be triggered manually via the GitHub UI
+name: Cargo publish Check
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    name: Run cargo-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install cargo-release
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-release
+          version: 0.18.4
+      - name: Run cargo-release
+        uses: actions-rs/cargo@v1
+        with:
+          command: release
+          # By default cargo-release run in dry-run mode.
+          # args: --no-confirm --execute --no-verify --dev-version
+

--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -3,10 +3,7 @@ name: Cargo publish Check
 on:
   push:
     tags:
-      - "*"
-  pull_request:
-    branches:
-      - master
+      - "*" # Run this validation on release tags
 
 jobs:
   release:

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -3,7 +3,7 @@ name: packaging
 on:
   push:
     tags:
-      - "*"
+      - '[0-9]+.[0-9]+.[0-9]+' # publish only on a release tag and not on RC candidates.
 
 jobs:
   wheel:

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -1,9 +1,9 @@
-name: packaging
+name: packaging and publish to pypi
 
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+' # publish only on a release tag and not on RC candidates.
+      - '*'
 
 jobs:
   wheel:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pravega-rust-client-examples"
+name = "pravega-client-examples"
 version = "0.3.1"
 edition = "2018"
 categories = ["network-programming"]

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,0 +1,2 @@
+# macros
+Macros used by Pravega client.

--- a/pravegactl/Cargo.toml
+++ b/pravegactl/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pravegactl"
-version = "0.0.1"
+version = "0.3.1"
 edition = "2018"
 categories = ["network-programming"]
 keywords = ["streaming", "client", "pravega"]
 readme = "Readme.md"
 repository = "https://github.com/pravega/pravega-client-rust"
 license = "Apache-2.0"
-description = "The integration test for pravega rust client."
+description = "A Pravega command-line tool, pravegactl, it allows you to run commands against Pravega clusters"
 authors = ["Tom Kaitchuck <Tom.Kaitchuck@dell.com>", "Wenqi Mou <wenqi.mou@dell.com>",
     "Sandeep Shridhar <sandeep.shridhar@dell.com>"]
 


### PR DESCRIPTION
**Change log description**  

* Automate cargo publish check for github tags.
* Ensure python bindings are published only on release tags.
* Add the missing ReadMe.md

**Purpose of the change**  
Fixes #337

**What the code does**  
* Automate cargo publish check for github tags.
* Ensure python bindings are published only on release tags.
* Add the missing ReadMe.md

**How to verify it**  
All the existing tests should continue to pass.
 https://github.com/pravega/pravega-client-rust/runs/4234022838?check_suite_focus=true verifies that this automation works.
