### PR TITLE
Issue 350: Wrong retention type in Python binding

### DIFF
--- a/python/src/stream_manager.rs
+++ b/python/src/stream_manager.rs
@@ -78,7 +78,7 @@ impl StreamRetentionPolicy {
     pub fn by_time(time_in_millis: i64) -> StreamRetentionPolicy {
         StreamRetentionPolicy {
             retention: Retention {
-                retention_type: RetentionType::Size,
+                retention_type: RetentionType::Time,
                 retention_param: time_in_millis,
             },
         }

--- a/python/src/stream_manager.rs
+++ b/python/src/stream_manager.rs
@@ -228,7 +228,7 @@ impl StreamManager {
     }
 
     ///
-    /// Create a Stream in Pravega
+    /// Create a Stream in Pravega.
     ///
     #[pyo3(text_signature = "($self, scope_name, stream_name, scaling_policy, retention_policy, tags)")]
     #[args(
@@ -288,7 +288,7 @@ impl StreamManager {
     }
 
     ///
-    /// Update Stream Configuration in Pravega
+    /// Update Stream Configuration in Pravega.
     ///
     #[pyo3(text_signature = "($self, scope_name, stream_name, scaling_policy, retention_policy, tags)")]
     #[args(
@@ -329,7 +329,7 @@ impl StreamManager {
     }
 
     ///
-    /// Get Stream tags from Pravega
+    /// Get Stream tags from Pravega.
     ///
     #[pyo3(text_signature = "($self, scope_name, stream_name, scaling_policy, retention_policy, tags)")]
     pub fn get_stream_tags(&self, scope_name: &str, stream_name: &str) -> PyResult<Option<Vec<String>>> {
@@ -353,7 +353,7 @@ impl StreamManager {
     }
 
     ///
-    /// Create a Stream in Pravega.
+    /// Seal a Stream in Pravega.
     ///
     #[pyo3(text_signature = "($self, scope_name, stream_name)")]
     pub fn seal_stream(&self, scope_name: &str, stream_name: &str) -> PyResult<bool> {


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**  
Fix the Wrong retention type in Python binding. `StreamRetentionPolicy.by_time()` should create a `Retention` with type `RetentionType::Time`.

**Purpose of the change**  
Fixes #350 

**What the code does**  
Change `RetentionType::Size` to `RetentionType::Time`. Also fix some typos in the Python doc.

**How to verify it**  
`cargo build` passes.
