### PR TITLE
Issue 368: Nodejs client should have a delete_reader_group function

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -80,6 +80,7 @@ stream_reader.release_segment(seg_slice);
 stream_reader.reader_offline();
 
 // Clean up.
+stream_manager.delete_reader_group(SCOPE, reader_group_name);
 stream_manager.seal_stream(SCOPE, STREAM);
 stream_manager.delete_stream(SCOPE, STREAM);
 stream_manager.delete_scope(SCOPE);

--- a/nodejs/native_cjs.ts
+++ b/nodejs/native_cjs.ts
@@ -34,6 +34,7 @@ export const {
     StreamRetentionStreamCutHead,
     StreamRetentionStreamCutTail,
     StreamManagerCreateReaderGroup,
+    StreamManagerDeleteReaderGroup,
     StreamManagerCreateWriter,
     StreamManagerToString,
     StreamReaderGroupCreateReader,

--- a/nodejs/native_esm.ts
+++ b/nodejs/native_esm.ts
@@ -46,6 +46,7 @@ export const {
     StreamRetentionStreamCutHead,
     StreamRetentionStreamCutTail,
     StreamManagerCreateReaderGroup,
+    StreamManagerDeleteReaderGroup,
     StreamManagerCreateWriter,
     StreamManagerToString,
     StreamReaderGroupCreateReader,

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -72,6 +72,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         StreamManager::js_create_reader_group,
     )?;
     cx.export_function(
+        "StreamManagerDeleteReaderGroup",
+        StreamManager::js_delete_reader_group,
+    )?;
+    cx.export_function(
         "StreamReaderGroupCreateReader",
         StreamReaderGroup::js_create_reader,
     )?;

--- a/nodejs/stream_manager.ts
+++ b/nodejs/stream_manager.ts
@@ -31,6 +31,7 @@ import {
     StreamRetentionStreamCutHead,
     StreamRetentionStreamCutTail,
     StreamManagerCreateReaderGroup,
+    StreamManagerDeleteReaderGroup,
     StreamManagerCreateWriter,
     StreamManagerCreateTxnWriter,
     StreamManagerToString,
@@ -226,6 +227,14 @@ export interface StreamManager {
     ) => StreamReaderGroup;
 
     /**
+     * Delete a ReaderGroup for a given Stream.
+     *
+     * @param scope_name The scope name.
+     * @param reader_group_name The reader group name.
+     */
+    delete_reader_group: (scope_name: string, reader_group_name: string) => void;
+
+    /**
      * Create a Writer for a given Stream.
      *
      * @param scope_name The scope name.
@@ -330,6 +339,8 @@ export const StreamManager = (
         StreamReaderGroup(
             StreamManagerCreateReaderGroup.call(stream_manager, reader_group_name, scope_name, streams, stream_cut)
         );
+    const delete_reader_group = (scope_name: string, reader_group_name: string) =>
+        StreamManagerDeleteReaderGroup.call(stream_manager, scope_name, reader_group_name);
     const create_writer = (scope_name: string, stream_name: string): StreamWriter =>
         StreamWriter(StreamManagerCreateWriter.call(stream_manager, scope_name, stream_name));
     const create_transaction_writer = (scope_name: string, stream_name: string, writer_id: BigInt): StreamTxnWriter =>
@@ -349,6 +360,7 @@ export const StreamManager = (
         delete_stream,
         list_streams,
         create_reader_group,
+        delete_reader_group,
         create_writer,
         create_transaction_writer,
         toString,

--- a/nodejs/tests/client.test.ts
+++ b/nodejs/tests/client.test.ts
@@ -72,6 +72,7 @@ describe('Basic test on manager, reader, and writer', () => {
         // }
         stream_reader.reader_offline();
 
+        stream_manager.delete_reader_group(SCOPE, reader_group_name);
         stream_manager.seal_stream(SCOPE, STREAM);
         stream_manager.delete_stream(SCOPE, STREAM);
         stream_manager.delete_scope(SCOPE);


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**  
Add delete_reader_group function in nodejs client.

**Purpose of the change**  
Fixes #368 

**What the code does**  
Wrap the rust `delete_reader_group`.

**How to verify it**  
nodejs/tests/client.test.ts with new `stream_manager.delete_reader_group(SCOPE, reader_group_name);` should pass without error.
