### PR TITLE
Added Python 3.10 in tagPublish.yml

### DIFF
--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         platform: [
         { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
         { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },


### PR DESCRIPTION
Signed-off-by: qian1166 <78283846+qian1166@users.noreply.github.com>

**Purpose of the change**  
CVE-2015-20107 security related issues need to upgrade python to the latest version

**What the code does**  
Added Python 3.10 in tagPublish.yml
