### PR TITLE
Use maximize-build-space Action in CIbuild workflow

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -61,6 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Maximize disk space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-android: true
+          remove-haskell: true
+          remove-dotnet: true
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -155,6 +161,12 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize disk space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-android: true
+          remove-haskell: true
+          remove-dotnet: true
       - name: Checkout sources
         uses: actions/checkout@v2
 


### PR DESCRIPTION
**Change log description**  
Fix PR build steps that are failing due to disk space issues.

**Purpose of the change**  
Issue TBD

**What the code does**  
Adds maximize-build-space GitHub Action to CIbuild workflow steps that are failing to build in PRs.

**How to verify it**  
All steps on this PR should pass.