### PR TITLE
Issue 395: Fix Test Suite job intermittently timeout Problem and Clippy related issues.

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
         
+      - name: Display Rust version
+        run: rustc --version
       - name: Cache toolchain
         uses: actions/cache@v1
         with:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -237,11 +237,11 @@ jobs:
         build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
         include:
           - build: linux
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable
             target: x86_64-unknown-linux-musl
           - build: linux-arm
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable
             target: arm-unknown-linux-gnueabihf
           - build: macos
@@ -253,7 +253,7 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
           - build: win-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable-x86_64-gnu
             target: x86_64-pc-windows-gnu
           - build: win32-msvc
@@ -266,7 +266,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install packages (Ubuntu)
-        if: matrix.os == 'ubuntu-18.04'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           .github/workflows/ubuntu-install-packages
 

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -23,22 +23,22 @@ jobs:
       - name: Display Rust version
         run: rustc --version
       - name: Cache toolchain
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /usr/share/rust/.cargo
           key: ${{ runner.os }}-rustup
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo build	
-        uses: actions/cache@v1	
+        uses: actions/cache@v3
         with:	
           path: target	
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
@@ -78,22 +78,22 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Cache toolchain
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /usr/share/rust/.cargo
           key: ${{ runner.os }}-rustup
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo build	
-        uses: actions/cache@v1	
+        uses: actions/cache@v3
         with:	
           path: target	
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
@@ -124,22 +124,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache toolchain
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /usr/share/rust/.cargo
           key: ${{ runner.os }}-rustup
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo build	
-        uses: actions/cache@v1	
+        uses: actions/cache@v3
         with:	
           path: target	
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
@@ -173,22 +173,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache toolchain
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /usr/share/rust/.cargo
           key: ${{ runner.os }}-rustup
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
       - name: Cache cargo build	
-        uses: actions/cache@v1	
+        uses: actions/cache@v3
         with:	
           path: target	
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -253,7 +253,7 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
           - build: win-gnu
-            os: windows-2019
+            os: ubuntu-18.04
             rust: stable-x86_64-gnu
             target: x86_64-pc-windows-gnu
           - build: win32-msvc

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -234,7 +234,7 @@ jobs:
 
     strategy:
       matrix:
-        build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
+        build: [linux, linux-arm, macos, win-msvc, win32-msvc]
         include:
           - build: linux
             os: ubuntu-18.04
@@ -252,10 +252,10 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-          - build: win-gnu
-            os: windows-2019
-            rust: stable-x86_64-gnu
-            target: x86_64-pc-windows-gnu
+#          - build: win-gnu
+#            os: windows-2019
+#            rust: stable-x86_64-gnu
+#            target: x86_64-pc-windows-gnu
           - build: win32-msvc
             os: windows-2019
             rust: stable

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -314,7 +314,7 @@ jobs:
           mkdir "$staging"
           echo "currentdir is :"
           pwd
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          if [ "${{ matrix.os }}" = "windows-2019" ] || [ "${{ matrix.build }}" = "win-gnu" ]; then
             cp "target/${{ matrix.target }}/release/pravegactl.exe" "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> $GITHUB_ENV

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -234,7 +234,7 @@ jobs:
 
     strategy:
       matrix:
-        build: [linux, linux-arm, macos, win-msvc, win32-msvc]
+        build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
         include:
           - build: linux
             os: ubuntu-18.04
@@ -252,10 +252,10 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-#          - build: win-gnu
-#            os: windows-2019
-#            rust: stable-x86_64-gnu
-#            target: x86_64-pc-windows-gnu
+          - build: win-gnu
+            os: windows-2019
+            rust: stable-x86_64-gnu
+            target: x86_64-pc-windows-gnu
           - build: win32-msvc
             os: windows-2019
             rust: stable
@@ -281,7 +281,7 @@ jobs:
       - name: Use Cross
         shell: bash
         run: |
-          cargo install cross
+          cargo install --version 0.2.4 cross // for more information please refer https://github.com/cross-rs/cross/issues/1214 
           echo "CARGO=cross" >> $GITHUB_ENV
           echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
           echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -280,8 +280,9 @@ jobs:
 
       - name: Use Cross
         shell: bash
+#        // Changed cargo version from latest to 0.2.4 for more information please refer https://github.com/cross-rs/cross/issues/1214
         run: |
-          cargo install --version 0.2.4 cross // for more information please refer https://github.com/cross-rs/cross/issues/1214 
+          cargo install --version 0.2.4 cross 
           echo "CARGO=cross" >> $GITHUB_ENV
           echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
           echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate_documentation:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -14,7 +14,7 @@ name: pythontest
 jobs:
   test_tox:
     name: run-tox
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v2

--- a/config/src/connection_type.rs
+++ b/config/src/connection_type.rs
@@ -24,12 +24,6 @@ pub enum MockType {
     WrongHost,
 }
 
-impl Default for ConnectionType {
-    fn default() -> Self {
-        ConnectionType::Tokio
-    }
-}
-
 impl fmt::Display for ConnectionType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -232,14 +232,17 @@ mod tests {
         let config = ClientConfigBuilder::default()
             .max_connections_in_pool(15 as u32)
             .connection_type(ConnectionType::Tokio)
-            .retry_policy(RetryWithBackoff::from_millis(1000))
+            .retry_policy(RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(100)))
             .controller_uri(PravegaNodeUri::from("127.0.0.2:9091".to_string()))
             .build()
             .unwrap();
 
         assert_eq!(config.max_connections_in_pool(), 15 as u32);
         assert_eq!(config.connection_type(), ConnectionType::Tokio);
-        assert_eq!(config.retry_policy(), RetryWithBackoff::from_millis(1000));
+        assert_eq!(
+            config.retry_policy(),
+            RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(100))
+        );
         assert_eq!(
             config.controller_uri().to_socket_addr().ip(),
             Ipv4Addr::new(127, 0, 0, 2)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
         let config = ClientConfigBuilder::default()
             .max_connections_in_pool(15 as u32)
             .connection_type(ConnectionType::Tokio)
-            .retry_policy(RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(100)))
+            .retry_policy(RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(1000)))
             .controller_uri(PravegaNodeUri::from("127.0.0.2:9091".to_string()))
             .build()
             .unwrap();
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(config.connection_type(), ConnectionType::Tokio);
         assert_eq!(
             config.retry_policy(),
-            RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(100))
+            RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(1000))
         );
         assert_eq!(
             config.controller_uri().to_socket_addr().ip(),

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -65,7 +65,7 @@ pub struct ClientConfig {
     pub connection_type: ConnectionType,
 
     #[get_copy = "pub"]
-    #[builder(default = "RetryWithBackoff::default()")]
+    #[builder(default = "RetryWithBackoff::default_setting()")]
     pub retry_policy: RetryWithBackoff,
 
     #[get]
@@ -258,7 +258,7 @@ mod tests {
         assert_eq!(config.max_connections_in_pool(), u32::MAX as u32);
         assert_eq!(config.max_controller_connections(), 3u32);
         assert_eq!(config.connection_type(), ConnectionType::Tokio);
-        assert_eq!(config.retry_policy(), RetryWithBackoff::default());
+        assert_eq!(config.retry_policy(), RetryWithBackoff::default_setting());
     }
 
     #[test]

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -1547,8 +1547,12 @@ impl ControllerClientImpl {
                 match scale_response.status() {
                     ScaleStreamStatus::Started => {
                         // scale Stream has started. check for its completion.
-                        self.check_scale_status(stream, scale_response.epoch, RetryWithBackoff::default_setting())
-                            .await
+                        self.check_scale_status(
+                            stream,
+                            scale_response.epoch,
+                            RetryWithBackoff::default_setting(),
+                        )
+                        .await
                     }
                     ScaleStreamStatus::PreconditionFailed => Err(ControllerError::OperationError {
                         can_retry: false, // do not retry.

--- a/controller-client/src/lib.rs
+++ b/controller-client/src/lib.rs
@@ -1547,7 +1547,7 @@ impl ControllerClientImpl {
                 match scale_response.status() {
                     ScaleStreamStatus::Started => {
                         // scale Stream has started. check for its completion.
-                        self.check_scale_status(stream, scale_response.epoch, RetryWithBackoff::default())
+                        self.check_scale_status(stream, scale_response.epoch, RetryWithBackoff::default_setting())
                             .await
                     }
                     ScaleStreamStatus::PreconditionFailed => Err(ControllerError::OperationError {

--- a/controller-client/src/test.rs
+++ b/controller-client/src/test.rs
@@ -17,7 +17,7 @@ fn test_create_scope_error() {
     let mut rt = Runtime::new().unwrap();
     let config = ClientConfigBuilder::default()
         .controller_uri("127.0.0.1:9090".parse::<SocketAddr>().unwrap())
-        .retry_policy(RetryWithBackoff::default().max_delay(Duration::from_micros(1)))
+        .retry_policy(RetryWithBackoff::default_setting().max_delay(Duration::from_micros(1)))
         .build()
         .expect("build client config");
 
@@ -43,7 +43,7 @@ fn test_create_stream_error() {
     let mut rt = Runtime::new().unwrap();
     let config = ClientConfigBuilder::default()
         .controller_uri("127.0.0.1:9090".parse::<SocketAddr>().unwrap())
-        .retry_policy(RetryWithBackoff::default().max_delay(Duration::from_micros(1)))
+        .retry_policy(RetryWithBackoff::default_setting().max_delay(Duration::from_micros(1)))
         .build()
         .expect("build client config");
     let client = ControllerClientImpl::new(config, rt.handle().clone());

--- a/integration_test/build.rs
+++ b/integration_test/build.rs
@@ -16,7 +16,8 @@ use tar::Archive;
 use tracing::info;
 
 const LIBRARY: &str = "pravega";
-const VERSION: &str = "0.10.1";
+const TAG: &str = "0.13.0-rc0";
+const VERSION: &str = "0.13.0";
 const BASE: &str = "./";
 
 fn main() {
@@ -47,7 +48,7 @@ fn remove_suffix(value: &mut String, suffix: &str) {
 fn install_prebuilt() {
     let url = format!(
         "https://github.com/pravega/pravega/releases/download/v{}/pravega-{}.tgz",
-        VERSION, VERSION
+        TAG, VERSION
     );
     let short_file_name = url.split('/').last().unwrap();
     let mut base_name = short_file_name.to_string();

--- a/integration_test/src/disconnection_tests.rs
+++ b/integration_test/src/disconnection_tests.rs
@@ -60,7 +60,7 @@ pub fn disconnection_test_wrapper() {
 
 #[allow(deprecated)]
 async fn test_retry_with_no_connection() {
-    let retry_policy = RetryWithBackoff::default().max_tries(4);
+    let retry_policy = RetryWithBackoff::default_setting().max_tries(4);
     // give a wrong endpoint
     let endpoint = PravegaNodeUri::from("127.0.0.1:0");
     let config = ConnectionFactoryConfig::new(ConnectionType::Tokio);
@@ -97,7 +97,7 @@ fn test_retry_while_start_pravega(cf: &ClientFactory) {
 
 #[allow(deprecated)]
 async fn create_scope_stream(controller_client: &dyn ControllerClient) {
-    let retry_policy = RetryWithBackoff::default().max_tries(10);
+    let retry_policy = RetryWithBackoff::default_setting().max_tries(10);
     let scope_name = Scope::from("retryScope".to_owned());
 
     let result = retry_async(retry_policy, || async {
@@ -129,7 +129,7 @@ async fn create_scope_stream(controller_client: &dyn ControllerClient) {
         },
         tags: None,
     };
-    let retry_policy = RetryWithBackoff::default().max_tries(10);
+    let retry_policy = RetryWithBackoff::default_setting().max_tries(10);
     let result = retry_async(retry_policy, || async {
         let result = controller_client.create_stream(&request).await;
         match result {
@@ -144,7 +144,7 @@ async fn create_scope_stream(controller_client: &dyn ControllerClient) {
 
 #[allow(deprecated)]
 fn test_retry_with_unexpected_reply(cf: &ClientFactory) {
-    let retry_policy = RetryWithBackoff::default().max_tries(4);
+    let retry_policy = RetryWithBackoff::default_setting().max_tries(4);
     let scope_name = Scope::from("retryScope".to_owned());
     let stream_name = Stream::from("retryStream".to_owned());
     let controller_client = cf.controller_client();
@@ -231,7 +231,7 @@ async fn test_with_mock_server() {
 
     // test with 3 requests, they should be all succeed.
     for _i in 0i32..3 {
-        let retry_policy = RetryWithBackoff::default().max_tries(5);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(5);
         let result = retry_async(retry_policy, || async {
             let connection = pool
                 .get_connection(endpoint.clone())

--- a/integration_test/src/event_reader_tests.rs
+++ b/integration_test/src/event_reader_tests.rs
@@ -42,7 +42,7 @@ pub fn test_event_stream_reader(config: PravegaStandaloneServiceConfig) {
     test_read_from_tail_of_stream(&async_client_factory);
     test_read_from_head_of_stream(&async_client_factory);
     test_read_large_events(&async_client_factory);
-    // test_multi_reader_multi_segments_tail_read(&async_client_factory);
+    test_multi_reader_multi_segments_tail_read(&async_client_factory);
     runtime.block_on(test_read_api(&async_client_factory));
     runtime.block_on(test_stream_scaling(&async_client_factory));
     runtime.block_on(test_release_segment(&async_client_factory));

--- a/integration_test/src/event_reader_tests.rs
+++ b/integration_test/src/event_reader_tests.rs
@@ -42,7 +42,7 @@ pub fn test_event_stream_reader(config: PravegaStandaloneServiceConfig) {
     test_read_from_tail_of_stream(&async_client_factory);
     test_read_from_head_of_stream(&async_client_factory);
     test_read_large_events(&async_client_factory);
-    test_multi_reader_multi_segments_tail_read(&async_client_factory);
+    // test_multi_reader_multi_segments_tail_read(&async_client_factory);
     runtime.block_on(test_read_api(&async_client_factory));
     runtime.block_on(test_stream_scaling(&async_client_factory));
     runtime.block_on(test_release_segment(&async_client_factory));

--- a/integration_test/src/event_reader_tests.rs
+++ b/integration_test/src/event_reader_tests.rs
@@ -585,7 +585,7 @@ fn test_segment_rebalance(client_factory: &ClientFactoryAsync) {
     let mut reader2 = h.block_on(rg.create_reader("r2".to_string()));
 
     // change the last seg acquire and release time to ensure segment balance is triggered.
-    let last_acquire_release_time = Instant::now() - Duration::from_secs(20);
+    let last_acquire_release_time = Instant::now().checked_sub(Duration::from_secs(20)).unwrap();
     reader1.set_last_acquire_release_time(last_acquire_release_time);
     reader2.set_last_acquire_release_time(last_acquire_release_time);
     let mut events_read = 0;
@@ -630,7 +630,7 @@ fn test_segment_rebalance(client_factory: &ClientFactoryAsync) {
     // set reader 2 offline. This should ensure all the segments assigned to reader2 are available to be assigned by reader1.else {  }
     h.block_on(reader2.reader_offline()).expect("reader offline");
     //reset the time to ensure reader1 acquires segment in the next cycle.
-    reader1.set_last_acquire_release_time(Instant::now() - Duration::from_secs(20));
+    reader1.set_last_acquire_release_time(Instant::now().checked_sub(Duration::from_secs(20)).unwrap());
 
     while let Some(slice) = h
         .block_on(reader1.acquire_segment())
@@ -800,9 +800,7 @@ fn test_read_from_tail_of_stream(client_factory: &ClientFactoryAsync) {
     const EVENT_SIZE: usize = 10;
 
     h.block_on(async {
-        let new_stream =
-            create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
-        new_stream
+        create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
     });
 
     let rg_config = ReaderGroupConfigBuilder::default()

--- a/integration_test/src/index_stream_tests.rs
+++ b/integration_test/src/index_stream_tests.rs
@@ -108,7 +108,7 @@ async fn test_write_and_read(
     // search for record when nothing in the stream
     let res = reader.search_offset(("id", 5)).await;
     assert!(
-        matches! {res.err().expect("search for a non-existing field"), IndexReaderError::FieldNotFound{..}}
+        matches! {res.expect_err("search for a non-existing field"), IndexReaderError::FieldNotFound{..}}
     );
 
     // test normal append
@@ -127,7 +127,7 @@ async fn test_write_and_read(
     let data = vec![1; 10];
     let res = writer.append(label, data).await;
     assert!(
-        matches! {res.err().expect("append should fail due to invalid label"), IndexWriterError::InvalidFields{..}}
+        matches! {res.expect_err("append should fail due to invalid label"), IndexWriterError::InvalidFields{..}}
     );
 
     // test tail read
@@ -171,7 +171,7 @@ async fn test_write_and_read(
     // search for future record, should return error.
     let res = reader.search_offset(("uuid", 11)).await;
     assert!(
-        matches! {res.err().expect("search for a non-existing field"), IndexReaderError::FieldNotFound{..}}
+        matches! {res.expect_err("search for a non-existing field"), IndexReaderError::FieldNotFound{..}}
     );
 
     // test event reader compatibility
@@ -232,7 +232,7 @@ async fn test_new_record(writer: &mut IndexWriter<TestFields1>, reader: &mut Ind
 
     let res = reader.search_offset(("id", 21)).await;
     assert!(
-        matches! {res.err().expect("search for a non-existing entry"), IndexReaderError::FieldNotFound{..}}
+        matches! {res.expect_err("search for a non-existing entry"), IndexReaderError::FieldNotFound{..}}
     );
     // test dup field search
     let label = TestFields1 {
@@ -289,7 +289,7 @@ async fn test_condition_append(writer: &mut IndexWriter<TestFields1>) {
     let data = vec![1; 21];
     let res = writer.append_conditionally(label, condition_on, data).await;
     assert!(
-        matches! {res.err().expect("should have conditional append error"), IndexWriterError::InvalidCondition{..}}
+        matches! {res.expect_err("should have conditional append error"), IndexWriterError::InvalidCondition{..}}
     );
     info!("test index stream condition append passed");
 }
@@ -303,6 +303,6 @@ async fn test_new_record_out_of_order(writer: &mut IndexWriter<TestFields2>) {
         timestamp: 21,
     };
     let res = writer.append(label, data).await;
-    assert!(matches! {res.err().expect("should have append error"), IndexWriterError::InvalidFields{..}});
+    assert!(matches! {res.expect_err("should have append error"), IndexWriterError::InvalidFields{..}});
     info!("test index stream new record out of order passed");
 }

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(bare_trait_objects)]
+#![allow(clippy::result_large_err)]
 
 use std::{thread, time};
 // use pravega_client_rust::metric;

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(bare_trait_objects)]
-#![allow(clippy::result_large_err)]
+#![allow(clippy::result_large_err)] // https://github.com/rust-lang/rust-clippy/issues/8971
 
 use std::{thread, time};
 // use pravega_client_rust::metric;

--- a/integration_test/src/pravega_service.rs
+++ b/integration_test/src/pravega_service.rs
@@ -131,7 +131,7 @@ impl PravegaService for PravegaStandaloneService {
     fn enable_debug_log(enable: bool) {
         let file_path = Path::new(&LOG);
         // Open and read the file entirely
-        let mut src = File::open(&file_path).expect("open logback.xml file");
+        let mut src = File::open(file_path).expect("open logback.xml file");
         let mut data = String::new();
         src.read_to_string(&mut data).expect("read data");
         drop(src); // Close the file early
@@ -144,13 +144,13 @@ impl PravegaService for PravegaStandaloneService {
         };
 
         // Recreate the file and dump the processed contents to it
-        let mut dst = File::create(&file_path).expect("create file");
+        let mut dst = File::create(file_path).expect("create file");
         dst.write_all(new_data.as_bytes()).expect("write file");
     }
 
     fn enable_auth(enable: bool) {
         let file_path = Path::new(&PROPERTY);
-        let file = File::open(&file_path).expect("open standalone property file");
+        let file = File::open(file_path).expect("open standalone property file");
         let mut map = read(BufReader::new(file)).expect("read property file");
 
         if enable {
@@ -172,13 +172,13 @@ impl PravegaService for PravegaStandaloneService {
         };
 
         // Recreate the file and dump the processed contents to it
-        let f = File::create(&file_path).expect("create file");
+        let f = File::create(file_path).expect("create file");
         write(BufWriter::new(f), &map).expect("write file");
     }
 
     fn enable_tls(enable: bool) {
         let file_path = Path::new(&PROPERTY);
-        let file = File::open(&file_path).expect("open standalone property file");
+        let file = File::open(file_path).expect("open standalone property file");
         let mut map = read(BufReader::new(file)).expect("read property file");
         // drop(src); // Close the file early
 
@@ -213,7 +213,7 @@ impl PravegaService for PravegaStandaloneService {
         };
 
         // Recreate the file and dump the processed contents to it
-        let f = File::create(&file_path).expect("create file");
+        let f = File::create(file_path).expect("create file");
         write(BufWriter::new(f), &map).expect("write file");
     }
 }

--- a/integration_test/src/reader_group_tests.rs
+++ b/integration_test/src/reader_group_tests.rs
@@ -55,9 +55,7 @@ fn test_read_offline_stream(client_factory: &ClientFactoryAsync) {
     const EVENT_SIZE: usize = 10;
 
     h.block_on(async {
-        let new_stream =
-            create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
-        new_stream
+        create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
     });
 
     let rg_config = ReaderGroupConfigBuilder::default()
@@ -124,9 +122,7 @@ fn test_read_offline_with_offset(client_factory: &ClientFactoryAsync) {
     const EVENT_SIZE: usize = 10;
     // create scope and stream.
     h.block_on(async {
-        let new_stream =
-            create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
-        new_stream
+        create_scope_stream(client_factory.controller_client(), &scope_name, &stream_name, 1).await;
     });
 
     let rg_config = ReaderGroupConfigBuilder::default()

--- a/integration_test/src/wirecommand_tests.rs
+++ b/integration_test/src/wirecommand_tests.rs
@@ -163,7 +163,7 @@ async fn test_hello(factory: &ClientFactory) {
         high_version: 10,
     });
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
     raw_client
         .send_request(&request)
         .await
@@ -187,7 +187,7 @@ async fn test_keep_alive(factory: &ClientFactory) {
         .expect("get endpoint for segment");
 
     let request = Requests::KeepAlive(KeepAliveCommand {});
-    let connection = (&*CONNECTION_POOL)
+    let connection = (*CONNECTION_POOL)
         .get_connection(endpoint)
         .await
         .expect("get connection");
@@ -226,7 +226,7 @@ async fn test_setup_append(factory: &ClientFactory) {
         last_event_number: i64::min_value(),
     });
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
     raw_client
         .send_request(&request)
         .await
@@ -272,7 +272,7 @@ async fn test_create_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request1 = Requests::CreateSegment(CreateSegmentCommand {
         request_id: 1,
@@ -323,7 +323,7 @@ async fn test_seal_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::SealSegment(SealSegmentCommand {
         segment: segment_name.to_string(),
@@ -357,7 +357,7 @@ async fn test_update_and_get_segment_attribute(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let sname = segment_name.to_string();
     let uid = Uuid::new_v4().as_u128();
@@ -418,7 +418,7 @@ async fn test_get_stream_segment_info(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let sname = segment_name.to_string();
     let request = Requests::GetStreamSegmentInfo(GetStreamSegmentInfoCommand {
@@ -452,7 +452,7 @@ async fn test_delete_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::DeleteSegment(DeleteSegmentCommand {
         request_id: 7,
@@ -484,7 +484,7 @@ async fn test_conditional_append_and_read_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::CreateSegment(CreateSegmentCommand {
         request_id: 8,
@@ -567,7 +567,7 @@ async fn test_update_segment_policy(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::UpdateSegmentPolicy(UpdateSegmentPolicyCommand {
         request_id: 12,
@@ -602,7 +602,7 @@ async fn test_merge_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::CreateSegment(CreateSegmentCommand {
         request_id: 13,
@@ -690,7 +690,7 @@ async fn test_truncate_segment(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     // truncate the first event1.
     let request = Requests::TruncateSegment(TruncateSegmentCommand {
@@ -725,7 +725,7 @@ async fn test_update_table_entries(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::CreateSegment(CreateSegmentCommand {
         request_id: 18,
@@ -829,7 +829,7 @@ async fn test_read_table_key(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::ReadTableKeys(ReadTableKeysCommand {
         request_id: 22,
@@ -868,7 +868,7 @@ async fn test_read_table(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let keys = vec![
         TableKey::new(String::from("key1").into_bytes(), i64::MIN),
@@ -920,7 +920,7 @@ async fn test_read_table_entries(factory: &ClientFactory) {
         .await
         .expect("get endpoint for segment");
 
-    let raw_client = RawClientWrapper::new(&*CONNECTION_POOL, endpoint, factory.config().request_timeout());
+    let raw_client = RawClientWrapper::new(&CONNECTION_POOL, endpoint, factory.config().request_timeout());
 
     let request = Requests::ReadTableEntries(ReadTableEntriesCommand {
         request_id: 22,

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#![allow(clippy::result_large_err)] // https://github.com/rust-lang/rust-clippy/issues/8971
 #[macro_use]
 extern crate derive_new;
 

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(clippy::result_large_err)] // https://github.com/rust-lang/rust-clippy/issues/8971
+#![allow(clippy::result_large_err)] //https://github.com/pravega/pravega-client-rust/issues/413
 #[macro_use]
 extern crate derive_new;
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8,6 +8,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#![allow(clippy::borrow_deref_ref)] // https://github.com/rust-lang/rust-clippy/issues/8971
 #[macro_use]
 extern crate cfg_if;
 

--- a/retry/src/lib.rs
+++ b/retry/src/lib.rs
@@ -25,7 +25,7 @@
 //!         Nonretryable,
 //!     }
 //!
-//! let retry_policy = RetryWithBackoff::default().max_tries(1);
+//! let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
 //! let mut collection = vec![1, 2].into_iter();
 //! let value = retry_sync(retry_policy, || match collection.next() {
 //!     Some(n) if n == 2 => RetryResult::Success(n),

--- a/retry/src/retry_async.rs
+++ b/retry/src/retry_async.rs
@@ -18,7 +18,7 @@ use tokio::time::sleep;
 /// Retry the given operation asynchronously until it succeeds,
 /// or until the given Duration iterator ends.
 /// It can be used as follows:
-/// let retry_policy = RetryWithBackoff::default();
+/// let retry_policy = RetryWithBackoff::default_setting();
 /// let future = retry_async(retry_policy, || async {
 ///     let previous = 1;
 ///     match previous {
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn attempts_just_once() {
         let runtime = Runtime::new().unwrap();
-        let retry_policy = RetryWithBackoff::default().max_tries(1);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
         let future = retry_async(retry_policy, || async {
             let previous = 1;
             match previous {
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn attempts_until_max_retries_exceeded() {
         let runtime = Runtime::new().unwrap();
-        let retry_policy = RetryWithBackoff::default().max_tries(3);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(3);
         let future = retry_async(retry_policy, || async {
             let previous = 3;
             match previous {
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn attempts_until_success() {
         let runtime = Runtime::new().unwrap();
-        let retry_policy = RetryWithBackoff::default().max_tries(3);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(3);
         let mut counter = 0;
 
         let future = retry_async(retry_policy, || {

--- a/retry/src/retry_policy.rs
+++ b/retry/src/retry_policy.rs
@@ -162,7 +162,9 @@ fn test_returns_with_finite_retries() {
 }
 #[test]
 fn test_returns_some_exponential_base_2() {
-    let mut s = RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(2));
+    let mut s = RetryWithBackoff::default_setting()
+        .initial_delay(Duration::from_millis(2))
+        .backoff_coefficient(2);
 
     assert_eq!(s.next(), Some(Duration::from_millis(2)));
     assert_eq!(s.next(), Some(Duration::from_millis(4)));

--- a/retry/src/retry_policy.rs
+++ b/retry/src/retry_policy.rs
@@ -35,7 +35,7 @@ pub struct RetryWithBackoff {
 impl RetryWithBackoff {
     /// Constructs a new exponential back-off strategy,
     /// using default setting.
-    pub fn default() -> RetryWithBackoff {
+    pub fn default_setting() -> RetryWithBackoff {
         RetryWithBackoff {
             attempt: 0,
 
@@ -132,7 +132,7 @@ impl Iterator for RetryWithBackoff {
 
 #[test]
 fn test_uses_default_setting() {
-    let mut s = RetryWithBackoff::default();
+    let mut s = RetryWithBackoff::default_setting();
 
     assert_eq!(s.next(), Some(Duration::from_millis(1)));
     assert_eq!(s.next(), Some(Duration::from_millis(10)));
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_without_max_attempt_without_max_delay_without_expiration_time() {
-        let mut s = RetryWithBackoff::default()
+        let mut s = RetryWithBackoff::default_setting()
             .initial_delay(Duration::from_millis(1))
             .backoff_coefficient(2);
 
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_with_max_attempt_without_max_delay_without_expiration_time() {
-        let mut s = RetryWithBackoff::default()
+        let mut s = RetryWithBackoff::default_setting()
             .initial_delay(Duration::from_millis(1))
             .backoff_coefficient(2)
             .max_attempt(4);
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_without_max_attempt_without_max_delay_with_expiration_time() {
-        let mut s = RetryWithBackoff::default()
+        let mut s = RetryWithBackoff::default_setting()
             .initial_delay(Duration::from_millis(1))
             .backoff_coefficient(2)
             .max_delay(Duration::from_millis(12));
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn test_without_max_attempt_with_max_delay_without_expiration_time() {
         let sleep_duration = Duration::from_millis(10);
-        let mut s = RetryWithBackoff::default()
+        let mut s = RetryWithBackoff::default_setting()
             .initial_delay(Duration::from_millis(1))
             .backoff_coefficient(2)
             .expiration_time(Instant::now().add(sleep_duration));
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_with_max_attempt_with_max_delay_without_expiration_time() {
-        let mut s = RetryWithBackoff::default()
+        let mut s = RetryWithBackoff::default_setting()
             .initial_delay(Duration::from_millis(1))
             .backoff_coefficient(2)
             .max_attempt(8)

--- a/retry/src/retry_policy.rs
+++ b/retry/src/retry_policy.rs
@@ -142,7 +142,7 @@ fn test_uses_default_setting() {
 
 #[test]
 fn test_returns_some_exponential_base_10() {
-    let mut s = RetryWithBackoff::from_millis(10);
+    let mut s = RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(10));
 
     assert_eq!(s.next(), Some(Duration::from_millis(10)));
     assert_eq!(s.next(), Some(Duration::from_millis(100)));
@@ -162,7 +162,7 @@ fn test_returns_with_finite_retries() {
 }
 #[test]
 fn test_returns_some_exponential_base_2() {
-    let mut s = RetryWithBackoff::from_millis(2);
+    let mut s = RetryWithBackoff::default_setting().initial_delay(Duration::from_millis(2));
 
     assert_eq!(s.next(), Some(Duration::from_millis(2)));
     assert_eq!(s.next(), Some(Duration::from_millis(4)));
@@ -171,7 +171,9 @@ fn test_returns_some_exponential_base_2() {
 
 #[test]
 fn stops_increasing_at_max_delay() {
-    let mut s = RetryWithBackoff::from_millis(2).max_delay(Duration::from_millis(4));
+    let mut s = RetryWithBackoff::default_setting()
+        .initial_delay(Duration::from_millis(2))
+        .max_delay(Duration::from_millis(4));
 
     assert_eq!(s.next(), Some(Duration::from_millis(2)));
     assert_eq!(s.next(), Some(Duration::from_millis(4)));
@@ -180,7 +182,9 @@ fn stops_increasing_at_max_delay() {
 
 #[test]
 fn returns_max_when_max_less_than_base() {
-    let mut s = RetryWithBackoff::from_millis(20).max_delay(Duration::from_millis(10));
+    let mut s = RetryWithBackoff::default_setting()
+        .initial_delay(Duration::from_millis(20))
+        .max_delay(Duration::from_millis(10));
     assert_eq!(s.next(), Some(Duration::from_millis(10)));
     assert_eq!(s.next(), Some(Duration::from_millis(10)));
 }

--- a/retry/src/retry_result.rs
+++ b/retry/src/retry_result.rs
@@ -63,7 +63,7 @@ pub trait Retryable {
 /// async fn function_a(param1: &str, param2:u8) -> Result<(), CustomError> {
 ///
 /// }
-/// let retry_policy = RetryWithBackoff::default().max_tries(10);
+/// let retry_policy = RetryWithBackoff::default_setting().max_tries(10);
 /// // the below invocation wraps function_a with the retry logic.
 /// wrap_with_async_retry!(retry_policy, function_a("test", 1));
 /// ```
@@ -104,7 +104,7 @@ macro_rules! wrap_with_async_retry {
 /// fn function_a(param1: &str, param2:u8) -> Result<(), CustomError>{
 ///
 /// }
-/// let retry_policy = RetryWithBackoff::default().max_tries(5);
+/// let retry_policy = RetryWithBackoff::default_setting().max_tries(5);
 /// // the below invocation wraps function_a with the retry logic.
 /// wrap_with_sync_retry!(retry_policy, function_a("test", 1));
 /// ```

--- a/retry/src/retry_sync.rs
+++ b/retry/src/retry_sync.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// Retry the given operation synchronously until it succeeds, or until the given `Duration` end.
 /// retry_schedule: The retry policy that has max retry times and retry delay.
 /// It can be used as follows:
-/// let retry_policy = RetryWithBackoff::default();
+/// let retry_policy = RetryWithBackoff::default_setting();
 /// let mut collection = vec![1, 2].into_iter();
 /// let res = retry_sync(retry_policy, || match collection.next() {
 ///     Some(n) if n == 3 => RetryResult::Success(n),
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_succeeds_with_default_setting() {
-        let retry_policy = RetryWithBackoff::default();
+        let retry_policy = RetryWithBackoff::default_setting();
         let mut collection = vec![1, 2, 3, 4, 5].into_iter();
         let value = retry_sync(retry_policy, || match collection.next() {
             Some(n) if n == 5 => RetryResult::Success(n),
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_succeeds_with_maximum_retries() {
-        let retry_policy = RetryWithBackoff::default().max_tries(1);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
         let mut collection = vec![1, 2].into_iter();
         let value = retry_sync(retry_policy, || match collection.next() {
             Some(n) if n == 2 => RetryResult::Success(n),
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_fails_after_last_retry() {
-        let retry_policy = RetryWithBackoff::default().max_tries(1);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
         let mut collection = vec![1, 2].into_iter();
         let res = retry_sync(retry_policy, || match collection.next() {
             Some(n) if n == 3 => RetryResult::Success(n),
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_fails_with_non_retryable_err() {
-        let retry_policy = RetryWithBackoff::default().max_tries(1);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
         let mut collection = vec![1].into_iter();
         let res = retry_sync(retry_policy, || match collection.next() {
             Some(n) if n == 3 => RetryResult::Success(n),
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_succeeds_with_snafu_error() {
-        let retry_policy = RetryWithBackoff::default().max_tries(1);
+        let retry_policy = RetryWithBackoff::default_setting().max_tries(1);
         let mut collection = vec![1, 2].into_iter();
         let res = retry_sync(retry_policy, || match collection.next() {
             Some(n) if n == 3 => RetryResult::Success(n),

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -399,10 +399,7 @@ impl EventReader {
         rg_state: Arc<Mutex<ReaderGroupState>>,
         meta: &mut ReaderState,
     ) -> Result<(), EventReaderError> {
-        let mut rg_guard = rg_state.lock().await;
-        let online = rg_guard.check_online(&reader_id).await;
-        drop(rg_guard);
-        if !meta.reader_offline && online {
+        if !meta.reader_offline && rg_state.lock().await.check_online(&reader_id).await {
             info!("static Putting reader {:?} offline", reader_id);
             // stop reading from all the segments.
             meta.stop_reading_all();

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -24,6 +24,7 @@ use bytes::{Buf, BufMut, BytesMut};
 use core::fmt;
 use im::HashMap as ImHashMap;
 use std::collections::{HashMap, HashSet};
+use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
@@ -123,19 +124,30 @@ impl Drop for EventReader {
         info!("Reader {:?} is dropped", self.id);
         // try fetching the currently running Runtime.
         let r = Handle::try_current();
+        let rg_state = self.rg_state.clone();
+        let id = self.id.clone();
+        let mut meta = mem::take(&mut self.meta);
         match r {
             Ok(handle) => {
                 // enter the runtime context.
                 let _ = handle.enter();
                 // ensure we block until the reader_offline method completes.
-                let offline_status = futures::executor::block_on(self.reader_offline());
-                info!("Reader {:?} is marked as offline. {:?}", self.id, offline_status);
+                tokio::spawn(async move {
+                    EventReader::reader_offline_internal(id, rg_state, &mut meta)
+                        .await
+                        .expect("Reader Offline");
+                });
+                info!("Reader {:?} is marked as offline.", self.id);
             }
             Err(_) => {
                 // ensure we block until the reader_offline executes successfully.
                 let rt = tokio::runtime::Runtime::new().expect("Create tokio runtime to drop reader");
-                let offline_status = rt.block_on(self.reader_offline());
-                info!("Reader {:?} is marked as offline. {:?}", self.id, offline_status);
+                rt.spawn(async move {
+                    EventReader::reader_offline_internal(id, rg_state, &mut meta)
+                        .await
+                        .expect("Reader Offline");
+                });
+                info!("Reader {:?} is marked as offline.", self.id);
             }
         }
     }
@@ -382,41 +394,41 @@ impl EventReader {
     /// Note: it may return an error indicating that the reader has already been removed. This means
     /// that another thread removes this reader from the ReaderGroup probably due to the host of this reader
     /// is assumed dead.
-    pub async fn reader_offline(&mut self) -> Result<(), EventReaderError> {
-        if !self.meta.reader_offline && self.rg_state.lock().await.check_online(&self.id).await {
-            info!("Putting reader {:?} offline", self.id);
+    async fn reader_offline_internal(
+        reader_id: Reader,
+        rg_state: Arc<Mutex<ReaderGroupState>>,
+        meta: &mut ReaderState,
+    ) -> Result<(), EventReaderError> {
+        let mut rg_guard = rg_state.lock().await;
+        let online = rg_guard.check_online(&reader_id).await;
+        drop(rg_guard);
+        if !meta.reader_offline && online {
+            info!("static Putting reader {:?} offline", reader_id);
             // stop reading from all the segments.
-            self.meta.stop_reading_all();
+            meta.stop_reading_all();
             // close all slice return Receivers.
-            self.meta.close_all_slice_return_channel();
+            meta.close_all_slice_return_channel();
             // use the updated map to return the data.
-
             let mut offset_map: HashMap<ScopedSegment, Offset> = HashMap::new();
-            for (seg, slice_meta) in self.meta.slices_dished_out.drain() {
+            for (seg, slice_meta) in meta.slices_dished_out.drain() {
                 offset_map.insert(seg, Offset::new(slice_meta.read_offset));
             }
-            for meta in self.meta.slices.values() {
+            for meta in meta.slices.values() {
                 offset_map.insert(
                     ScopedSegment::from(meta.scoped_segment.as_str()),
                     Offset::new(meta.read_offset),
                 );
             }
 
-            match self
-                .rg_state
-                .lock()
-                .await
-                .remove_reader(&self.id, offset_map)
-                .await
-            {
+            match rg_state.lock().await.remove_reader(&reader_id, offset_map).await {
                 Ok(()) => {
-                    self.meta.reader_offline = true;
+                    meta.reader_offline = true;
                     Ok(())
                 }
                 Err(e) => match e {
                     ReaderGroupStateError::ReaderAlreadyOfflineError { .. } => {
-                        self.meta.reader_offline = true;
-                        info!("Reader {:?} is already offline", self.id);
+                        meta.reader_offline = true;
+                        info!("staticReader {:?} is already offline", reader_id);
                         Ok(())
                     }
                     state_err => Err(EventReaderError::StateError { source: state_err }),
@@ -424,6 +436,17 @@ impl EventReader {
             }?
         }
         Ok(())
+    }
+
+    /// Mark the reader as offline after calling the reader_offline_internal.
+    /// Note: it may return an error indicating that the reader has already been removed. This means
+    /// that another thread removes this reader from the ReaderGroup probably due to the host of this reader
+    /// is assumed dead.
+    pub async fn reader_offline(&mut self) -> Result<(), EventReaderError> {
+        let rg_state = self.rg_state.clone();
+        let id = self.id.clone();
+        let mut meta = mem::take(&mut self.meta);
+        Self::reader_offline_internal(id, rg_state, &mut meta).await
     }
 
     /// Release the segment of the provided SegmentSlice from the reader. This segment is marked as
@@ -784,6 +807,21 @@ struct ReaderState {
     last_segment_release: Instant,
     last_segment_acquire: Instant,
     reader_offline: bool,
+}
+impl Default for ReaderState {
+    // Implements the Default trait for the ReaderState struct.
+    // This allows us to create a new instance of ReaderState with default values using the Default::default() method.
+    fn default() -> Self {
+        ReaderState {
+            slices: HashMap::new(),
+            slices_dished_out: HashMap::new(),
+            slice_release_receiver: HashMap::new(),
+            slice_stop_reading: HashMap::new(),
+            last_segment_release: Instant::now(),
+            last_segment_acquire: Instant::now(),
+            reader_offline: false,
+        }
+    }
 }
 
 impl ReaderState {

--- a/src/event/reader_group_state.rs
+++ b/src/event/reader_group_state.rs
@@ -258,8 +258,7 @@ impl ReaderGroupState {
         &mut self,
         reader: &Reader,
     ) -> Result<(), ReaderGroupStateError> {
-        self
-            .sync
+        self.sync
             .insert(|table| ReaderGroupState::remove_reader_internal_default(table, reader))
             .await
             .map_err(|err| match err {
@@ -303,8 +302,7 @@ impl ReaderGroupState {
         reader: &Reader,
         owned_segments: HashMap<ScopedSegment, Offset>,
     ) -> Result<(), ReaderGroupStateError> {
-        self
-            .sync
+        self.sync
             .insert(|table| ReaderGroupState::remove_reader_internal(table, reader, &owned_segments))
             .await
             .map_err(|err| match err {
@@ -566,8 +564,7 @@ impl ReaderGroupState {
         segment_completed: &ScopedSegment,
         successors_mapped_to_their_predecessors: &im::HashMap<SegmentWithRange, Vec<Segment>>,
     ) -> Result<(), ReaderGroupStateError> {
-        self
-            .sync
+        self.sync
             .insert(|table| {
                 ReaderGroupState::segment_completed_internal(
                     table,

--- a/src/event/reader_group_state.rs
+++ b/src/event/reader_group_state.rs
@@ -258,7 +258,7 @@ impl ReaderGroupState {
         &mut self,
         reader: &Reader,
     ) -> Result<(), ReaderGroupStateError> {
-        let _res_str = self
+        self
             .sync
             .insert(|table| ReaderGroupState::remove_reader_internal_default(table, reader))
             .await
@@ -303,7 +303,7 @@ impl ReaderGroupState {
         reader: &Reader,
         owned_segments: HashMap<ScopedSegment, Offset>,
     ) -> Result<(), ReaderGroupStateError> {
-        let _res_str = self
+        self
             .sync
             .insert(|table| ReaderGroupState::remove_reader_internal(table, reader, &owned_segments))
             .await
@@ -566,7 +566,7 @@ impl ReaderGroupState {
         segment_completed: &ScopedSegment,
         successors_mapped_to_their_predecessors: &im::HashMap<SegmentWithRange, Vec<Segment>>,
     ) -> Result<(), ReaderGroupStateError> {
-        let _res_str = self
+        self
             .sync
             .insert(|table| {
                 ReaderGroupState::segment_completed_internal(

--- a/src/index/reader.rs
+++ b/src/index/reader.rs
@@ -139,7 +139,7 @@ impl IndexReader {
             msg: format!("error when fetching tail offset: {:?}", e),
         })? as i64;
         let mut start = 0;
-        let num_of_record = (tail - head) as i64 / RECORD_SIZE_SIGNED;
+        let num_of_record = (tail - head) / RECORD_SIZE_SIGNED;
         let mut end = num_of_record - 1;
 
         while start <= end {
@@ -187,7 +187,7 @@ impl IndexReader {
         end_offset: u64,
     ) -> Result<impl Stream<Item = Result<Vec<u8>, IndexReaderError>> + 'stream, IndexReaderError> {
         ensure!(
-            start_offset % (RECORD_SIZE as u64) == 0,
+            start_offset % (RECORD_SIZE) == 0,
             InvalidOffset {
                 msg: format!(
                     "Start offset {} is invalid as it cannot be divided by the record size {}",
@@ -197,7 +197,7 @@ impl IndexReader {
         );
         if end_offset != u64::MAX {
             ensure!(
-                end_offset % (RECORD_SIZE as u64) == 0,
+                end_offset % (RECORD_SIZE) == 0,
                 InvalidOffset {
                     msg: format!(
                         "End offset {} is invalid as it cannot be divided by the record size {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::needless_borrow,
     clippy::similar_names
 )]
+// clippy::result_large_err will be fixed by https://github.com/pravega/pravega-client-rust/issues/413.
 #![allow(
     clippy::multiple_crate_versions,
     clippy::result_large_err,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
     clippy::needless_borrow,
     clippy::similar_names
 )]
-#![allow(clippy::multiple_crate_versions, clippy::needless_doctest_main)]
+#![allow(clippy::multiple_crate_versions, clippy::result_large_err, clippy::needless_doctest_main)]
 #![allow(bare_trait_objects)]
 #![recursion_limit = "1024"]
 #![allow(clippy::redundant_allocation)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,11 @@
     clippy::needless_borrow,
     clippy::similar_names
 )]
-#![allow(clippy::multiple_crate_versions, clippy::result_large_err, clippy::needless_doctest_main)]
+#![allow(
+    clippy::multiple_crate_versions,
+    clippy::result_large_err,
+    clippy::needless_doctest_main
+)]
 #![allow(bare_trait_objects)]
 #![recursion_limit = "1024"]
 #![allow(clippy::redundant_allocation)]

--- a/src/sync/table.rs
+++ b/src/sync/table.rs
@@ -152,7 +152,7 @@ impl Table {
                 .get_endpoint_for_segment(&segment)
                 .await
                 .expect("get endpoint for segment");
-            debug!("endpoint is {}", endpoint.to_string());
+            debug!("endpoint is {:?}", endpoint);
 
             let result = factory
                 .create_raw_client_for_endpoint(endpoint.clone())
@@ -944,7 +944,7 @@ async fn delete_table_segment(
         .get_endpoint_for_segment(segment)
         .await
         .expect("get endpoint for segment");
-    debug!("endpoint is {}", endpoint.to_string());
+    debug!("endpoint is {:?}", endpoint);
 
     let result = factory
         .create_raw_client_for_endpoint(endpoint.clone())

--- a/wire_protocol/src/mock_connection.rs
+++ b/wire_protocol/src/mock_connection.rs
@@ -91,10 +91,10 @@ impl Connection for MockConnection {
                 send_happy(
                     self.sender.as_mut().expect("get sender"),
                     payload,
-                    &mut *segments_guard,
-                    &mut *writers_guard,
-                    &mut *table_segment_index_guard,
-                    &mut *table_segment_guard,
+                    &mut segments_guard,
+                    &mut writers_guard,
+                    &mut table_segment_index_guard,
+                    &mut table_segment_guard,
                 )
                 .await
             }
@@ -232,10 +232,10 @@ impl ConnectionWriteHalf for MockWritingConnection {
                 send_happy(
                     &mut self.sender,
                     payload,
-                    &mut *segments_guard,
-                    &mut *writers_guard,
-                    &mut *table_segment_index_guard,
-                    &mut *table_segment_guard,
+                    &mut segments_guard,
+                    &mut writers_guard,
+                    &mut table_segment_index_guard,
+                    &mut table_segment_guard,
                 )
                 .await
             }
@@ -499,7 +499,7 @@ async fn send_happy(
                 entries: TableEntries { entries: delta },
                 should_clear: false,
                 reached_end: false,
-                last_position: to_position as i64,
+                last_position: to_position,
             });
             sender.send(reply).expect("send reply");
         }


### PR DESCRIPTION
**Change log description**  
Fixes the Test suit job intermittently timeout problem. also fixes Clippy related issues like duplicate default method etc.

Purpose of the change
Fixes #395 #404 

**What the code does**  
The code does following :-
1- Creates a internal function reader_offline.
2- Calls that method inside one of thread in the destructor.
3- Initializes the values of readerState to default
4- Drops the unused lock (which was causing the deadlock) 
5- Fixes the clippy related issue by following the clippy rules

**How to verify it**  
This can be verified on local by running following 

```
 cargo fmt --check --all
 cargo clippy --workspace
 cargo test -p pravega-connection-pool -p pravega-client-channel -p pravega-controller-client -p pravega-client-integration-test -p pravega-client-retry -p pravega-client-shared -p pravega-wire-protocol -p pravega-client -p pravega-client-auth -p pravega-client-config
```
