### PR TITLE
Issue 418:  Update maturin,tox; Removes python 3.6 and fix crate, pypi related GA

### DIFF
--- a/.github/workflows/build_wheel.py
+++ b/.github/workflows/build_wheel.py
@@ -17,7 +17,7 @@ command = [
     "maturin",
     "build",
     "--release",
-    "--compatibility=manylinux_2_28",
+    "--compatibility=manylinux_2_35",
     "--interpreter",
     sys.executable,
 ]

--- a/.github/workflows/build_wheel.py
+++ b/.github/workflows/build_wheel.py
@@ -17,7 +17,7 @@ command = [
     "maturin",
     "build",
     "--release",
-    "--no-sdist",
+    "--compatibility=manylinux_2_28",
     "--interpreter",
     sys.executable,
 ]

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -4,11 +4,14 @@ on:
   # Trigger the workflow on push or pull request,
   # but only for the master branch
   push:
+    tags:
+      - '*'
     branches:
-      - master
+      - master  
   pull_request:
     branches:
       - master
+      
 
 name: CIbuild
 
@@ -264,7 +267,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
+      - name: Set release version
+        # Set release version env in all three os, the commented command only works in linux and mac.
+        run: python3 -c "import os; tag = os.environ['GITHUB_REF'].split('/')[-1]; f = open(os.environ['GITHUB_ENV'], 'a'); f.write('RELEASE_VERSION='+tag); f.close();"
+        # run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Install packages (Ubuntu)
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -328,4 +334,15 @@ jobs:
         with:
           name: ${{ env.ASSET }}
           path: ${{ env.ASSET }}
-          retention-days: 5
+          retention-days: 5  
+      - name: Upload to Github releases
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        #working-directory: ${{ env.ASSET }} 
+        # Use bash, even on Windows to make find available
+        shell: bash
+        # A release need to be created before upload
+        run: gh release upload ${{ env.RELEASE_VERSION }} ${{ env.ASSET }}   --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate Pravega Python API documentation.
         run: |
-          pip install 'maturin>=0.11,<0.12' virtualenv pdoc3
+          pip install 'maturin>=0.14,<0.15' virtualenv pdoc3
           virtualenv venv
           source venv/bin/activate
           maturin develop -m python/Cargo.toml

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 

--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - run: git checkout HEAD^
       - name: Cache toolchain
         uses: actions/cache@v1
         with:
@@ -41,4 +43,6 @@ jobs:
       - name: Install cargo-release
         run: cargo install cargo-release
       - name: Release (Dry Run)
-        run: cargo release --workspace -vv --exclude pravega-client-integration-test --exclude pravega-client-examples --exclude pravegactl
+        run: cargo release --allow-branch '*' --dry-run -v -p pravega-client-auth -p pravega-client-channel -p pravega-client-config -p pravega-client-macros -p pravega-client-retry -p pravega-client-shared -p pravega-connection-pool -p pravega-controller-client -p pravega -p pravega-wire-protocol
+      - name: Release
+        run: cargo release -v -p pravega-client-auth -p pravega-client-channel -p pravega-client-config -p pravega-client-macros -p pravega-client-retry -p pravega-client-shared -p pravega-connection-pool -p pravega-controller-client -p pravega -p pravega-wire-protocol

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin>=0.14,<0.15' virtualenv tox==3.5.3 tox-pyo3
+        run: pip install 'maturin>=0.14,<0.15' virtualenv tox==3.28.0 tox-pyo3
       - name: Test with tox
         run: tox -c python/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin>=0.11,<0.12' virtualenv tox
+        run: pip install 'maturin>=0.14,<0.15' virtualenv tox
       - name: Test with tox
         run: tox -c python/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin>=0.14,<0.15' virtualenv tox
+        run: pip install 'maturin>=0.14,<0.15' virtualenv tox tox_pyo3
       - name: Test with tox
         run: tox -c python/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -28,7 +28,7 @@ jobs:
           pravega-0.10.0-2906.6a34e64-SNAPSHOT/bin/pravega-standalone > pravega.log 2>&1 &
           sleep 120 && echo "Started standalone"
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
       - name: Install stable toolchain

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin>=0.14,<0.15' virtualenv tox tox_pyo3
+        run: pip install 'maturin>=0.14,<0.15' virtualenv tox
       - name: Test with tox
         run: tox -c python/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Install maturin and tox
-        run: pip install 'maturin>=0.14,<0.15' virtualenv tox
+        run: pip install 'maturin>=0.14,<0.15' virtualenv tox==3.5.3 tox-pyo3
       - name: Test with tox
         run: tox -c python/tox.ini
       - name: Upload Pravega standalone logs

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         platform: [
-        { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
+        { os: "ubuntu-20.04",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
         { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
         { os: "windows-latest", python-architecture: "x64", rust-target: "x86_64-pc-windows-msvc" },
         # { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },
@@ -50,7 +50,7 @@ jobs:
           components: rustfmt, clippy
       - run: rustup set default-host ${{ matrix.platform.rust-target }}
       - name: install maturin
-        run: pip install 'maturin>=0.11,<0.12'
+        run: pip install 'maturin>=0.14,<0.15'
       - name: build wheel
         id: build_wheel
         run: python -u .github/workflows/build_wheel.py

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         platform: [
-        { os: "ubuntu-20.04",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
+        { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
         { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
         { os: "windows-latest", python-architecture: "x64", rust-target: "x86_64-pc-windows-msvc" },
         # { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -36,6 +36,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - name: Set release version
+        # Set release version env in all three os, the commented command only works in linux and mac.
+        run: python3 -c "import os; tag = os.environ['GITHUB_REF'].split('/')[-1]; f = open(os.environ['GITHUB_ENV'], 'a'); f.write('RELEASE_VERSION='+tag); f.close();"
+        # run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
@@ -66,6 +70,16 @@ jobs:
         run: |
           pip install -U twine
           python -m twine upload --skip-existing target/wheels/*
+      - name: Upload to Github releases
+        working-directory: ./target
+        # Use bash, even on Windows to make find available
+        shell: bash
+        # A release need to be created before upload
+        run: gh release upload ${{ env.RELEASE_VERSION }} "$(find ./wheels -name *.whl)" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
 
   nodejs-npm:
     name: nodejs-npm

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,13 +10,6 @@ license = "Apache-2.0"
 description = "Pravega client"
 authors = ["Pravega Community"]
 
-[package.metadata.maturin]
-classifier = ["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Rust", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9",]
-requires-python = ">=3.6"
-[package.metadata.maturin.project-url]
-Homepage= "https://pravega.github.io/pravega-client-rust/"
 
 [lib]
 name = "pravega_client"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 
 classifiers = ["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Rust", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7",
+    "Programming Language :: Rust",  "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10",]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 url= "https://pravega.github.io/pravega-client-rust/"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,4 +1,10 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
+
+classifiers = ["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Rust", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10",]
+requires-python = ">=3.6"
+url= "https://pravega.github.io/pravega-client-rust/"

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 minversion = 3.4.0
 skip_missing_interpreters = true
 isolated_build = true

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py37
-minversion = 3.4.0
 skip_missing_interpreters = true
 isolated_build = true
 requires = tox-pyo3


### PR DESCRIPTION
**Change log description**  

- Updates maturin to >=0.14,<0.15. This requires to fix the incompatible linux tag in python wheel.
- Removes support for python 3.6 as it's near EOL and many dependencies dropped support for it. 
- Maturin has dropped support python 3.6 since 0.13.0 - https://github.com/PyO3/maturin/releases/tag/v0.13.0
- Adds `manylinux_2_35` to the python wheels as a name tag to make them compatible with pypi.
- Installs specific version of tox==3.28.0 and also tox-pyo3.
- Fixes Cargo release issue.


**Purpose of the change**  
Fixes #418, #420, Closes #378 

**How to verify it**  

- All the CI should run successfully.
- Once a tag is created wheels should be uploaded to pypi.