### PR TITLE
Issue 423: Update node version for prebuilt binary

### DIFF
--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -15,6 +15,13 @@ jobs:
     name: run-jest
     runs-on: ubuntu-20.04
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - 16
+          - 18
+          - 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -29,7 +36,7 @@ jobs:
       - name: Set up Nodejs
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: ${{ matrix.node_version }}
       - name: Install modules
         working-directory: ./nodejs
         run: npm i

--- a/.github/workflows/tagPublish.yml
+++ b/.github/workflows/tagPublish.yml
@@ -79,8 +79,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
-
   nodejs-npm:
     name: nodejs-npm
     runs-on: ubuntu-latest
@@ -129,9 +127,9 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - 12
-          - 14
           - 16
+          - 18
+          - 20
         system:
           - os: macos-11
             target: x86_64-apple-darwin


### PR DESCRIPTION
**Change log description**  
According to the [README](https://github.com/nodejs/Release/blob/b4b46113a259b19db074a7fd47b552d84c0883f4/README.md) of node/release, 12 and 14 are no longer supported. We need to maintain versions 16, 18, and 20.

**Purpose of the change**  
Fixes #423

**What the code does**  
Update nodejs version to 16, 18, and 20.

**How to verify it**  
.github\workflows\nodejs_test.yml should pass.
