### PR TITLE
Issue: 425 Adds -x (--execute) flag to cargo release.

### DIFF
--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - run: git checkout HEAD^
       - name: Cache toolchain
         uses: actions/cache@v1
         with:
@@ -43,6 +42,7 @@ jobs:
       - name: Install cargo-release
         run: cargo install cargo-release
       - name: Release (Dry Run)
-        run: cargo release --allow-branch '*' --dry-run -v -p pravega-client-auth -p pravega-client-channel -p pravega-client-config -p pravega-client-macros -p pravega-client-retry -p pravega-client-shared -p pravega-connection-pool -p pravega-controller-client -p pravega -p pravega-wire-protocol
+        run: cargo release --allow-branch '*' --dry-run -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
       - name: Release
-        run: cargo release -v -p pravega-client-auth -p pravega-client-channel -p pravega-client-config -p pravega-client-macros -p pravega-client-retry -p pravega-client-shared -p pravega-connection-pool -p pravega-controller-client -p pravega -p pravega-wire-protocol
+        run: cargo release --allow-branch '*' -x -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
+


### PR DESCRIPTION
**Change log description**  

- Cargo release is a dry-run by default even if `dry-run` is not mentioned explicitly.
- To make it an actual release, we have to provide `-x` or `--execute` flag in the command.
- Fixes other cargo release related errors.

**Purpose of the change**  
Fixes #425 

**What the code does**  
- Adds `-x` flag in the `publish_check.yml` workflow.

**How to verify it**  

- Verified it on the forked repo. https://github.com/kotlasaicharanreddy/pravega-client-rust/actions/runs/4946424072/workflow