### PR TITLE
Issue 428: Correcting the password credentials in standalone properties

### DIFF
--- a/integration_test/src/pravega_service.rs
+++ b/integration_test/src/pravega_service.rs
@@ -164,7 +164,7 @@ impl PravegaService for PravegaStandaloneService {
                 "admin".to_string(),
             );
             map.insert(
-                "singlenode.security.auth.credentials.password".to_string(),
+                "singlenode.security.auth.credentials.pwd".to_string(),
                 "1111_aaaa".to_string(),
             );
         } else {


### PR DESCRIPTION
**Change log description**  
When running the standalone it throws an NPE repeatedly.

**Purpose of the change**  
Fixes #428 

**What the code does**  
The actual property what is being read in Pravega standalone is "security.auth.credentials.pwd" but while running rust client integration test cases it was being set as "singlenode.security.auth.credentials.password" because of which the password credentials was being set as empty.

**How to verify it**  
Below error should not be coming in the test logs.
SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1StreamCreated@450526dd
java.lang.NullPointerException: startCall() returned a null listener for method io.pravega.controller.stream.api.grpc.v1.ControllerService/getCurrentSegments
	
