### PR TITLE
Issue 430: Make cargo release non-interactive.

### DIFF
--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Release (Dry Run)
         run: cargo release --allow-branch '*' --dry-run -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
       - name: Release
-        run: cargo release --allow-branch '*' -x -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
+        run: cargo release --allow-branch '*' -x --no-confirm -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
 


### PR DESCRIPTION
**Change log description**  
- Adds `--no-confirm` flag to the cargo release command.

**Purpose of the change**  
Fixes #430 

**What the code does**  
- Makes the cargo release non-interactive.

**How to verify it**  
- All github actions should pass.
