### PR TITLE
Issue 432: Adds CARGO_REGISTRY_TOKEN secret in publish_check.yaml

### DIFF
--- a/.github/workflows/publish_check.yml
+++ b/.github/workflows/publish_check.yml
@@ -45,4 +45,6 @@ jobs:
         run: cargo release --allow-branch '*' --dry-run -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
       - name: Release
         run: cargo release --allow-branch '*' -x --no-confirm -v -p pravega-client-shared -p pravega-client-macros -p pravega-client-channel -p pravega-client-retry -p pravega-connection-pool -p pravega-client-config -p pravega-wire-protocol -p pravega-controller-client -p pravega-client-auth
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
**Change log description**  

- A token named `CARGO_REGISTRY_TOKEN` is required for the publishing of rust artifacts to the repository. 
- This pr address by adding the above mentioned token in the `publish_check.yaml` which triggeres the release of rust to crate.io repository.

**Purpose of the change**  
Fixes #432 

**What the code does**  

- Add CARGO_REGISTRY_TOKEN secret

**How to verify it**  

- All tests and github actions should be green.
- Whenever a new tag/release is created, rust artifacts/release should be published to crates.io repository.