### PR TITLE
Issue 434: Removes wildcard (*) dependency constraints 

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -28,4 +28,4 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 
 [dev-dependencies]
-serial_test = "*"
+serial_test = "2.0.0"


### PR DESCRIPTION
**Change log description**  

- wildcard (*) dependency constraints are not allowed on crates.io.
- So, removed (*) wildcard and added the lastest version of serial_test:v2.0.0

**Purpose of the change**  
Fixes #434 

**What the code does** 

- Adds v2.0.0 to the serial_test

**How to verify it**  

- All github actions should pass.
- Once a tag/release is created, then rust artifacts should be published to crates.io